### PR TITLE
Add preview server lifecycle management

### DIFF
--- a/apps/server/src/preview/preview.controller.ts
+++ b/apps/server/src/preview/preview.controller.ts
@@ -50,6 +50,9 @@ export class PreviewController {
       });
     }
 
+    // Register this connection
+    this.previewService.registerConnection(projectId);
+
     // Start watching if not already
     let subject = this.fileWatcherService.getChangeSubject(projectId);
     if (!subject) {
@@ -62,6 +65,8 @@ export class PreviewController {
     res.on("close", () => {
       closeSubject.next();
       closeSubject.complete();
+      // Unregister connection and potentially stop preview
+      this.previewService.unregisterConnection(projectId);
     });
 
     // Send heartbeat every 30 seconds to keep connection alive

--- a/apps/web/src/components/preview/PreviewPanel.tsx
+++ b/apps/web/src/components/preview/PreviewPanel.tsx
@@ -101,6 +101,25 @@ export function PreviewPanel({ projectId }: PreviewPanelProps) {
     setIsMounted(true);
   }, []);
 
+  // Cleanup preview when leaving the page
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      // Use sendBeacon for reliable delivery during page unload
+      const url = `${API_BASE}/projects/${projectId}/preview/stop`;
+      navigator.sendBeacon(url);
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      // Also stop preview on component unmount (navigation)
+      if (status === "running" || status === "starting") {
+        stopPreview(projectId);
+      }
+    };
+  }, [projectId, status, stopPreview]);
+
   // Reset state when project changes
   useEffect(() => {
     prevReadyRef.current = false;


### PR DESCRIPTION
## Summary
- Stop all preview servers on ClaudeShip server shutdown (OnModuleDestroy)
- Auto-stop preview when SSE connection closes (no active connections)
- Cleanup preview on page leave/refresh using sendBeacon API

## Changes
- `PreviewService`: Added `OnModuleDestroy`, connection tracking, auto-cleanup
- `PreviewController`: Register/unregister connections on SSE watch
- `PreviewPanel`: Call stop API on beforeunload and component unmount

Closes #3