### PR TITLE
Separate release workflows for Trusted Publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/docs.yml'
-  workflow_call:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,6 @@ name: Publish to npm
 on:
   release:
     types: [published]
-  workflow_call:
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,33 +8,16 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
-  pages: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Release Please
-        id: release
         uses: google-github-actions/release-please-action@v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  # Trigger npm publish when release is created
-  npm-publish:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
-    uses: ./.github/workflows/npm-publish.yml
-    secrets: inherit
-
-  # Trigger GitHub Pages deploy when release is created
-  pages-deploy:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
-    uses: ./.github/workflows/docs.yml
-    secrets: inherit
+# Note: npm-publish.yml triggers on release:published event
+# Note: docs.yml triggers on push to docs/** or workflow_dispatch


### PR DESCRIPTION
## Summary
- Remove workflow_call from npm-publish and docs workflows
- npm-publish triggers independently on `release:published` event
- docs triggers on push to docs/** or workflow_dispatch

This fixes the npm Trusted Publishing issue where workflow_call changes the workflow path.

Closes #4