### PR TITLE
Update release-please action with PAT support

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,17 +5,14 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
       - name: Release Please
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PAT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary
- Migrate from deprecated `google-github-actions/release-please-action` to `googleapis/release-please-action`
- Use `RELEASE_PAT` secret to trigger `release:published` event for npm-publish workflow

## Required Setup
Add `RELEASE_PAT` secret with these permissions:
- Contents: Read & Write
- Pull requests: Read & Write