### PR TITLE
feat: Add file attachment support in chat

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -24,6 +24,7 @@
     "@prisma/client": "^6.1.0",
     "chokidar": "^5.0.0",
     "http-proxy-middleware": "^3.0.3",
+    "multer": "^2.0.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },
@@ -31,6 +32,7 @@
     "@nestjs/cli": "^10.4.0",
     "@nestjs/schematics": "^10.2.0",
     "@types/express": "^5.0.0",
+    "@types/multer": "^2.0.0",
     "@types/node": "^22.10.0",
     "@typescript-eslint/eslint-plugin": "^8.18.0",
     "@typescript-eslint/parser": "^8.18.0",

--- a/apps/server/src/chat/chat.controller.ts
+++ b/apps/server/src/chat/chat.controller.ts
@@ -57,7 +57,12 @@ export class ChatController {
     @Param("projectId") projectId: string,
     @Body() dto: SendMessageDto
   ): Observable<MessageEvent> {
-    return this.chatService.sendMessage(projectId, dto.content, dto.mode);
+    return this.chatService.sendMessage(
+      projectId,
+      dto.content,
+      dto.mode,
+      dto.attachments
+    );
   }
 
   @Post("chat/reset")

--- a/apps/server/src/chat/chat.service.ts
+++ b/apps/server/src/chat/chat.service.ts
@@ -114,7 +114,8 @@ export class ChatService {
   sendMessage(
     projectId: string,
     content: string,
-    mode: ChatMode = "build"
+    mode: ChatMode = "build",
+    attachments?: string[]
   ): Observable<MessageEvent> {
     const sessionId = randomUUID();
 
@@ -193,7 +194,17 @@ export class ChatService {
 
           // Add mode-specific prompt for Ask mode
           const modePrompt = mode === "ask" ? ASK_MODE_PROMPT : "";
-          const fullPrompt = `[System Context]\n${systemPrompt}${modePrompt}\n\n${conversationContext}[User Request]\n${content}`;
+
+          // Build attachments context if any
+          let attachmentsContext = "";
+          if (attachments && attachments.length > 0) {
+            const attachmentPaths = attachments.map(
+              (relativePath) => `${projectPath}/${relativePath}`
+            );
+            attachmentsContext = `[Attached Files]\nThe user has attached the following files. Please analyze them using the Read tool:\n${attachmentPaths.map((p) => `- ${p}`).join("\n")}\n\n`;
+          }
+
+          const fullPrompt = `[System Context]\n${systemPrompt}${modePrompt}\n\n${conversationContext}${attachmentsContext}[User Request]\n${content}`;
 
           this.logger.log(`Chat mode: ${mode}`);
 

--- a/apps/server/src/chat/dto/send-message.dto.ts
+++ b/apps/server/src/chat/dto/send-message.dto.ts
@@ -3,4 +3,5 @@ export type ChatMode = "ask" | "build";
 export class SendMessageDto {
   content: string;
   mode?: ChatMode;
+  attachments?: string[];
 }

--- a/apps/server/src/file/file.controller.ts
+++ b/apps/server/src/file/file.controller.ts
@@ -1,5 +1,15 @@
-import { Controller, Get, Param, Query } from "@nestjs/common";
-import { FileService, FileNode } from "./file.service";
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Query,
+  UseInterceptors,
+  UploadedFiles,
+  BadRequestException,
+} from "@nestjs/common";
+import { FilesInterceptor } from "@nestjs/platform-express";
+import { FileService, FileNode, UploadedFile } from "./file.service";
 
 @Controller("projects/:projectId/files")
 export class FileController {
@@ -19,5 +29,38 @@ export class FileController {
     @Query("path") filePath: string
   ): Promise<{ content: string; language: string }> {
     return this.fileService.getFileContent(projectId, filePath);
+  }
+
+  @Post("upload")
+  @UseInterceptors(
+    FilesInterceptor("files", 5, {
+      limits: { fileSize: 10 * 1024 * 1024 },
+      fileFilter: (req, file, cb) => {
+        const allowedMimes = [
+          "image/png",
+          "image/jpeg",
+          "image/gif",
+          "image/webp",
+          "application/pdf",
+          "text/plain",
+          "text/markdown",
+        ];
+        if (allowedMimes.includes(file.mimetype)) {
+          cb(null, true);
+        } else {
+          cb(new BadRequestException(`File type not allowed: ${file.mimetype}`), false);
+        }
+      },
+    })
+  )
+  async uploadFiles(
+    @Param("projectId") projectId: string,
+    @UploadedFiles() files: Express.Multer.File[]
+  ): Promise<{ files: UploadedFile[] }> {
+    if (!files || files.length === 0) {
+      throw new BadRequestException("No files uploaded");
+    }
+    const uploadedFiles = await this.fileService.uploadFiles(projectId, files);
+    return { files: uploadedFiles };
   }
 }

--- a/apps/web/src/components/chat/ChatPanel.tsx
+++ b/apps/web/src/components/chat/ChatPanel.tsx
@@ -81,6 +81,7 @@ export function ChatPanel({ projectId }: ChatPanelProps) {
       />
       <MessageInput
         onSend={handleSend}
+        projectId={projectId}
         isStreaming={isStreaming}
         queueCount={messageQueue.length}
       />

--- a/apps/web/src/components/chat/FilePreview.tsx
+++ b/apps/web/src/components/chat/FilePreview.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { X, FileText, Loader2 } from "lucide-react";
+import { AttachedFile } from "@/stores/useChatStore";
+
+interface FilePreviewProps {
+  files: AttachedFile[];
+  onRemove: (id: string) => void;
+}
+
+export function FilePreview({ files, onRemove }: FilePreviewProps) {
+  if (files.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2 px-4 pb-2">
+      {files.map((file) => (
+        <div
+          key={file.id}
+          className="group relative flex items-center gap-2 rounded-lg border bg-muted/50 p-2"
+        >
+          {file.preview ? (
+            <img
+              src={file.preview}
+              alt={file.file.name}
+              className="h-12 w-12 rounded object-cover"
+            />
+          ) : (
+            <div className="flex h-12 w-12 items-center justify-center rounded bg-muted">
+              <FileText className="h-6 w-6 text-muted-foreground" />
+            </div>
+          )}
+          <div className="flex flex-col">
+            <span className="max-w-[120px] truncate text-xs font-medium">
+              {file.file.name}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {formatFileSize(file.file.size)}
+            </span>
+          </div>
+          {file.status === "uploading" && (
+            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+          )}
+          {file.status === "error" && (
+            <span className="text-xs text-destructive">{file.error}</span>
+          )}
+          <button
+            onClick={() => onRemove(file.id)}
+            className="absolute -right-2 -top-2 flex h-5 w-5 items-center justify-center rounded-full bg-destructive text-destructive-foreground opacity-0 transition-opacity group-hover:opacity-100"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/apps/web/src/components/chat/MessageInput.tsx
+++ b/apps/web/src/components/chat/MessageInput.tsx
@@ -1,33 +1,101 @@
 "use client";
 
-import { useState, useRef, KeyboardEvent } from "react";
-import { Send, Clock } from "lucide-react";
+import { useState, useRef, KeyboardEvent, DragEvent, ChangeEvent } from "react";
+import { Send, Clock, Paperclip } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useTranslation } from "@/lib/i18n";
 import { ModeToggle } from "./ModeToggle";
+import { FilePreview } from "./FilePreview";
 import { useChatStore } from "@/stores/useChatStore";
 
 interface MessageInputProps {
-  onSend: (content: string) => void;
+  onSend: (content: string, attachments?: string[]) => void;
+  projectId: string;
   disabled?: boolean;
   isStreaming?: boolean;
   queueCount?: number;
 }
 
-export function MessageInput({ onSend, disabled, isStreaming, queueCount = 0 }: MessageInputProps) {
+const ALLOWED_FILE_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+  "text/plain",
+  "text/markdown",
+];
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const MAX_FILES = 5;
+
+export function MessageInput({ onSend, projectId, disabled, isStreaming, queueCount = 0 }: MessageInputProps) {
   const { t } = useTranslation();
-  const { mode } = useChatStore();
+  const { mode, attachedFiles, addFiles, removeFile, uploadFiles, isUploading } = useChatStore();
   const [content, setContent] = useState("");
+  const [isDragging, setIsDragging] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const getPlaceholder = () => {
     if (isStreaming) return t("chat.queuePlaceholder");
     return mode === "ask" ? t("chat.askPlaceholder") : t("chat.placeholder");
   };
 
-  const handleSubmit = () => {
-    if (!content.trim() || disabled) return;
-    onSend(content.trim());
+  const handleFilesSelected = (files: File[]) => {
+    const validFiles = files.filter((file) => {
+      if (!ALLOWED_FILE_TYPES.includes(file.type)) {
+        console.warn(`File type not allowed: ${file.type}`);
+        return false;
+      }
+      if (file.size > MAX_FILE_SIZE) {
+        console.warn(`File too large: ${file.name}`);
+        return false;
+      }
+      return true;
+    });
+
+    const remaining = MAX_FILES - attachedFiles.length;
+    if (remaining <= 0) return;
+
+    addFiles(validFiles.slice(0, remaining));
+  };
+
+  const handleFileInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      handleFilesSelected(Array.from(e.target.files));
+      e.target.value = "";
+    }
+  };
+
+  const handleDragOver = (e: DragEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+  };
+
+  const handleDrop = (e: DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+    if (e.dataTransfer.files) {
+      handleFilesSelected(Array.from(e.dataTransfer.files));
+    }
+  };
+
+  const handleSubmit = async () => {
+    if ((!content.trim() && attachedFiles.length === 0) || disabled || isUploading) return;
+
+    // Upload files first if any
+    let attachments: string[] = [];
+    if (attachedFiles.length > 0) {
+      attachments = await uploadFiles(projectId);
+    }
+
+    onSend(content.trim(), attachments.length > 0 ? attachments : undefined);
     setContent("");
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
@@ -50,11 +118,35 @@ export function MessageInput({ onSend, disabled, isStreaming, queueCount = 0 }: 
   };
 
   return (
-    <div className="border-t bg-background p-4">
-      <div className="mb-3">
+    <div
+      className={`border-t bg-background ${isDragging ? "ring-2 ring-ring ring-offset-2" : ""}`}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      <div className="p-4 pb-2">
         <ModeToggle />
       </div>
-      <div className="flex items-end gap-2">
+      <FilePreview files={attachedFiles} onRemove={removeFile} />
+      <div className="flex items-end gap-2 px-4 pb-4">
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept={ALLOWED_FILE_TYPES.join(",")}
+          onChange={handleFileInputChange}
+          className="hidden"
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={disabled || attachedFiles.length >= MAX_FILES}
+          className="h-10 w-10 shrink-0"
+        >
+          <Paperclip className="h-4 w-4" />
+        </Button>
         <div className="relative flex-1">
           <textarea
             ref={textareaRef}
@@ -65,24 +157,31 @@ export function MessageInput({ onSend, disabled, isStreaming, queueCount = 0 }: 
             placeholder={getPlaceholder()}
             disabled={disabled}
             rows={1}
-            className="w-full resize-none rounded-lg border border-input bg-background px-4 py-3 pr-12 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+            className="w-full resize-none rounded-lg border border-input bg-background px-4 py-3 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
           />
         </div>
         <Button
           onClick={handleSubmit}
-          disabled={!content.trim() || disabled}
+          disabled={(!content.trim() && attachedFiles.length === 0) || disabled || isUploading}
           size="icon"
           className="h-10 w-10 shrink-0"
         >
           <Send className="h-4 w-4" />
         </Button>
       </div>
-      {isStreaming && (
-        <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
-          <span className="flex items-center gap-1">
-            <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-yellow-500" />
-            {t("chat.thinking")}
-          </span>
+      {(isStreaming || isUploading) && (
+        <div className="px-4 pb-4 flex items-center gap-2 text-xs text-muted-foreground">
+          {isUploading ? (
+            <span className="flex items-center gap-1">
+              <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-blue-500" />
+              {t("chat.uploading")}
+            </span>
+          ) : (
+            <span className="flex items-center gap-1">
+              <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-yellow-500" />
+              {t("chat.thinking")}
+            </span>
+          )}
           {queueCount > 0 && (
             <span className="flex items-center gap-1 text-blue-500">
               <Clock className="h-3 w-3" />

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -25,6 +25,15 @@ async function request<T>(
   return response.json();
 }
 
+export interface UploadedFile {
+  id: string;
+  originalName: string;
+  fileName: string;
+  path: string;
+  mimeType: string;
+  size: number;
+}
+
 export const api = {
   get: <T>(endpoint: string) => request<T>(endpoint),
   post: <T>(endpoint: string, data?: unknown) =>
@@ -39,4 +48,25 @@ export const api = {
     }),
   delete: <T>(endpoint: string) =>
     request<T>(endpoint, { method: "DELETE" }),
+
+  uploadFiles: async (
+    projectId: string,
+    files: File[]
+  ): Promise<{ files: UploadedFile[] }> => {
+    const formData = new FormData();
+    files.forEach((file) => formData.append("files", file));
+
+    const url = `${API_BASE_URL}/projects/${projectId}/files/upload`;
+    const response = await fetch(url, {
+      method: "POST",
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ message: "Upload failed" }));
+      throw new Error(error.message || `HTTP error! status: ${response.status}`);
+    }
+
+    return response.json();
+  },
 };

--- a/apps/web/src/lib/i18n/translations/en.json
+++ b/apps/web/src/lib/i18n/translations/en.json
@@ -44,6 +44,7 @@
     "queuePlaceholder": "Queue another message...",
     "send": "Send",
     "thinking": "AI is thinking...",
+    "uploading": "Uploading files...",
     "queueCount": "{count} message(s) queued",
     "toolRunning": "Running",
     "toolCompleted": "Completed",

--- a/apps/web/src/lib/i18n/translations/ko.json
+++ b/apps/web/src/lib/i18n/translations/ko.json
@@ -44,6 +44,7 @@
     "queuePlaceholder": "다음 메시지를 입력하세요...",
     "send": "전송",
     "thinking": "AI가 생각 중...",
+    "uploading": "파일 업로드 중...",
     "queueCount": "{count}개의 메시지가 대기 중",
     "toolRunning": "실행 중",
     "toolCompleted": "완료",

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -47,6 +47,7 @@ export interface AskUserQuestionData {
 export interface SendMessageInput {
   content: string;
   mode?: ChatMode;
+  attachments?: string[];
 }
 
 export type StreamEventType =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
       http-proxy-middleware:
         specifier: ^3.0.3
         version: 3.0.5
+      multer:
+        specifier: ^2.0.2
+        version: 2.0.2
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -50,6 +53,9 @@ importers:
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
+      '@types/multer':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.3
@@ -152,10 +158,10 @@ importers:
         version: 10.4.23(postcss@8.5.6)
       eslint:
         specifier: ^9.17.0
-        version: 9.39.2(jiti@1.21.7)
+        version: 9.39.2(jiti@2.6.1)
       eslint-config-next:
         specifier: ^15.1.0
-        version: 15.5.9(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+        version: 15.5.9(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       postcss:
         specifier: ^8.4.49
         version: 8.5.6
@@ -961,6 +967,9 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/multer@2.0.0':
+    resolution: {integrity: sha512-C3Z9v9Evij2yST3RSBktxP9STm6OdMc5uR1xF1SGr98uv8dUlAL2hqwrZ3GVB3uyMyiegnscEK6PGtYvNrjTjw==}
 
   '@types/node@22.19.3':
     resolution: {integrity: sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==}
@@ -3913,11 +3922,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.2(jiti@1.21.7))':
-    dependencies:
-      eslint: 9.39.2(jiti@1.21.7)
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.9.0(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
@@ -4581,6 +4585,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/multer@2.0.0':
+    dependencies:
+      '@types/express': 5.0.6
+
   '@types/node@22.19.3':
     dependencies:
       undici-types: 6.21.0
@@ -4612,22 +4620,6 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.50.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.50.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.50.1
-      '@typescript-eslint/type-utils': 8.50.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.50.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.50.1
-      eslint: 9.39.2(jiti@1.21.7)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.3.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@8.50.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -4640,18 +4632,6 @@ snapshots:
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.3.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.50.1
-      '@typescript-eslint/types': 8.50.1
-      '@typescript-eslint/typescript-estree': 8.50.1(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.50.1
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -4686,18 +4666,6 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.50.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.50.1
-      '@typescript-eslint/typescript-estree': 8.50.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.50.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@1.21.7)
-      ts-api-utils: 2.3.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/type-utils@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.50.1
@@ -4723,17 +4691,6 @@ snapshots:
       semver: 7.7.3
       tinyglobby: 0.2.15
       ts-api-utils: 2.3.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.50.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@1.21.7))
-      '@typescript-eslint/scope-manager': 8.50.1
-      '@typescript-eslint/types': 8.50.1
-      '@typescript-eslint/typescript-estree': 8.50.1(typescript@5.9.3)
-      eslint: 9.39.2(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -5562,19 +5519,19 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-next@15.5.9(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3):
+  eslint-config-next@15.5.9(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 15.5.9
       '@rushstack/eslint-patch': 1.15.0
-      '@typescript-eslint/eslint-plugin': 8.50.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.50.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@1.21.7)
+      '@typescript-eslint/eslint-plugin': 8.50.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.6.1))
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5594,33 +5551,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.50.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@1.21.7)
+      '@typescript-eslint/parser': 8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5629,9 +5586,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -5643,13 +5600,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.50.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -5659,7 +5616,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -5678,11 +5635,11 @@ snapshots:
       '@types/eslint': 9.6.1
       eslint-config-prettier: 9.1.2(eslint@9.39.2(jiti@2.6.1))
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
 
-  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -5690,7 +5647,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.2.2
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -5717,47 +5674,6 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
-
-  eslint@9.39.2(jiti@1.21.7):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@1.21.7))
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.1
-      '@eslint/config-helpers': 0.4.2
-      '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.3
-      '@eslint/js': 9.39.2
-      '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.7
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      eslint-scope: 8.4.0
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      esquery: 1.6.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    optionalDependencies:
-      jiti: 1.21.7
-    transitivePeerDependencies:
-      - supports-color
 
   eslint@9.39.2(jiti@2.6.1):
     dependencies:


### PR DESCRIPTION
## Summary
- 채팅에서 이미지/파일 첨부 기능 추가
- 드래그앤드롭 및 파일 선택 UI 구현
- 첨부 파일을 Claude에게 전달하여 분석 가능

## Changes
- 백엔드: 파일 업로드 API (`POST /files/upload`)
- 프론트엔드: 파일 첨부 버튼, 미리보기, 드래그앤드롭
- Claude CLI: 첨부 파일 경로를 프롬프트에 포함

## Supported Files
- 이미지: png, jpg, gif, webp
- 문서: pdf, txt, md
- 제한: 최대 10MB, 한 번에 5개

## Test plan
- [ ] 이미지 파일 첨부 후 메시지 전송
- [ ] 드래그앤드롭으로 파일 첨부
- [ ] 파일 미리보기 및 삭제 기능 확인
- [ ] Claude가 첨부 파일을 분석하는지 확인

Closes #11