### PR TITLE
fix: Add Python/FastAPI backend recognition in preview panel

### DIFF
--- a/apps/web/src/components/preview/PreviewPanel.tsx
+++ b/apps/web/src/components/preview/PreviewPanel.tsx
@@ -347,16 +347,33 @@ export function PreviewPanel({ projectId }: PreviewPanelProps) {
                 {/* Backend Status (for fullstack) */}
                 {projectReady.isFullstack && projectReady.backend && (
                   <div className="border rounded-lg p-2">
-                    <p className="font-medium mb-1.5 text-foreground">Backend</p>
+                    <p className="font-medium mb-1.5 text-foreground">
+                      Backend {projectReady.backendFramework === "FASTAPI" ? "(Python)" : "(Node.js)"}
+                    </p>
                     <div className="space-y-1">
-                      <div className="flex items-center justify-center gap-2">
-                        <div className={`h-2 w-2 rounded-full ${projectReady.backend.hasPackageJson ? "bg-green-500" : "bg-gray-300 animate-pulse"}`} />
-                        <span>package.json</span>
-                      </div>
-                      <div className="flex items-center justify-center gap-2">
-                        <div className={`h-2 w-2 rounded-full ${projectReady.backend.hasDevScript ? "bg-green-500" : "bg-gray-300"}`} />
-                        <span>dev script</span>
-                      </div>
+                      {projectReady.backendFramework === "FASTAPI" ? (
+                        <>
+                          <div className="flex items-center justify-center gap-2">
+                            <div className={`h-2 w-2 rounded-full ${projectReady.backend.hasRequirementsTxt ? "bg-green-500" : "bg-gray-300 animate-pulse"}`} />
+                            <span>requirements.txt</span>
+                          </div>
+                          <div className="flex items-center justify-center gap-2">
+                            <div className={`h-2 w-2 rounded-full ${projectReady.backend.hasMainPy ? "bg-green-500" : "bg-gray-300"}`} />
+                            <span>main.py</span>
+                          </div>
+                        </>
+                      ) : (
+                        <>
+                          <div className="flex items-center justify-center gap-2">
+                            <div className={`h-2 w-2 rounded-full ${projectReady.backend.hasPackageJson ? "bg-green-500" : "bg-gray-300 animate-pulse"}`} />
+                            <span>package.json</span>
+                          </div>
+                          <div className="flex items-center justify-center gap-2">
+                            <div className={`h-2 w-2 rounded-full ${projectReady.backend.hasDevScript ? "bg-green-500" : "bg-gray-300"}`} />
+                            <span>dev script</span>
+                          </div>
+                        </>
+                      )}
                     </div>
                   </div>
                 )}

--- a/apps/web/src/stores/usePreviewStore.ts
+++ b/apps/web/src/stores/usePreviewStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { api } from "@/lib/api";
-import type { PreviewStatus, PreviewStatusType } from "@claudeship/shared";
+import type { PreviewStatus, PreviewStatusType, BackendFramework } from "@claudeship/shared";
 
 interface DirectoryStatus {
   hasPackageJson: boolean;
@@ -8,11 +8,23 @@ interface DirectoryStatus {
   hasDevScript: boolean;
 }
 
+interface BackendDirectoryStatus {
+  // Express (Node.js)
+  hasPackageJson?: boolean;
+  hasNodeModules?: boolean;
+  hasDevScript?: boolean;
+  // FastAPI (Python)
+  hasRequirementsTxt?: boolean;
+  hasVenv?: boolean;
+  hasMainPy?: boolean;
+}
+
 interface ProjectReadyStatus {
   ready: boolean;
   isFullstack: boolean;
+  backendFramework?: BackendFramework;
   frontend: DirectoryStatus;
-  backend?: DirectoryStatus;
+  backend?: BackendDirectoryStatus;
 }
 
 interface PreviewState {


### PR DESCRIPTION
## Summary
- FastAPI(Python) 백엔드 프로젝트가 Preview 패널에서 제대로 인식되지 않는 문제 수정
- 프레임워크 타입에 따라 다른 준비도 체크 및 UI 표시

## Changes

### Backend (`preview.service.ts`)
- `checkPythonDirectoryReady()` 메서드 추가
  - `requirements.txt` 존재 여부 확인
  - `main.py` (또는 `app/main.py`) 존재 여부 확인
  - `venv` 디렉토리 존재 여부 확인
- `checkProjectReady()` 응답에 `backendFramework` 필드 추가
- Express와 FastAPI 프로젝트를 다르게 처리

### Frontend (`PreviewPanel.tsx`, `usePreviewStore.ts`)
- `BackendDirectoryStatus` 인터페이스 확장 (Python용 필드 추가)
- 프레임워크에 따라 다른 상태 표시:
  - Express: `package.json`, `dev script`
  - FastAPI: `requirements.txt`, `main.py`

## Test plan
- [ ] FastAPI 백엔드 프로젝트 생성 시 Preview 패널 확인
- [ ] Express 백엔드 프로젝트는 기존과 동일하게 동작 확인

Closes #14