### PR TITLE
feat: Add CSV and Excel file support for attachments

### DIFF
--- a/apps/server/src/file/file.controller.ts
+++ b/apps/server/src/file/file.controller.ts
@@ -44,6 +44,9 @@ export class FileController {
           "application/pdf",
           "text/plain",
           "text/markdown",
+          "text/csv",
+          "application/vnd.ms-excel",
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         ];
         if (allowedMimes.includes(file.mimetype)) {
           cb(null, true);

--- a/apps/server/src/file/file.service.ts
+++ b/apps/server/src/file/file.service.ts
@@ -166,6 +166,9 @@ export class FileService {
     "application/pdf",
     "text/plain",
     "text/markdown",
+    "text/csv",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
   ];
 
   async uploadFiles(

--- a/apps/web/src/components/chat/MessageInput.tsx
+++ b/apps/web/src/components/chat/MessageInput.tsx
@@ -24,6 +24,9 @@ const ALLOWED_FILE_TYPES = [
   "application/pdf",
   "text/plain",
   "text/markdown",
+  "text/csv",
+  "application/vnd.ms-excel",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 ];
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB


### PR DESCRIPTION
## Summary
파일 첨부에 CSV 및 Excel 파일 지원 추가

## Supported File Types
- `text/csv` - CSV 파일
- `application/vnd.ms-excel` - Excel 97-2003 (.xls)
- `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` - Excel 2007+ (.xlsx)