### PR TITLE
feat: Add agent-triggered preview restart via special marker

### DIFF
--- a/apps/server/src/chat/prompts/fullstack-express-prompt.ts
+++ b/apps/server/src/chat/prompts/fullstack-express-prompt.ts
@@ -371,6 +371,22 @@ DATABASE_URL="file:./dev.db"
 The preview system automatically handles starting both frontend and backend servers.
 Your job is to create/modify files and run \`npm install\` when needed - NOT to start servers.
 
+## Preview Server Restart
+
+When you make changes that require the preview server to restart, output this marker:
+
+\`\`\`
+<restart-preview />
+\`\`\`
+
+**When to use:**
+- After modifying package.json or installing dependencies
+- After changing configuration files (next.config.js, tailwind.config.ts, etc.)
+- After modifying backend server code (Express routes, middleware, etc.)
+- When hot-reload doesn't pick up changes
+
+The marker will automatically trigger a restart and won't be visible to the user.
+
 ## Checklist
 
 - [ ] frontend/ 디렉토리에 Next.js 앱 구성

--- a/apps/server/src/chat/prompts/fullstack-fastapi-prompt.ts
+++ b/apps/server/src/chat/prompts/fullstack-fastapi-prompt.ts
@@ -353,6 +353,22 @@ DATABASE_URL=sqlite+aiosqlite:///./dev.db
 The preview system automatically handles starting both frontend and backend servers.
 Your job is to create/modify files and run \`pip install\` / \`npm install\` when needed - NOT to start servers.
 
+## Preview Server Restart
+
+When you make changes that require the preview server to restart, output this marker:
+
+\`\`\`
+<restart-preview />
+\`\`\`
+
+**When to use:**
+- After modifying package.json, requirements.txt, or installing dependencies
+- After changing configuration files (next.config.js, tailwind.config.ts, etc.)
+- After modifying backend server code (FastAPI routes, middleware, etc.)
+- When hot-reload doesn't pick up changes
+
+The marker will automatically trigger a restart and won't be visible to the user.
+
 ## Checklist
 
 - [ ] frontend/ 디렉토리에 Next.js 앱 구성

--- a/apps/server/src/chat/prompts/web-system-prompt.ts
+++ b/apps/server/src/chat/prompts/web-system-prompt.ts
@@ -231,6 +231,21 @@ export function Counter() {
 }
 \`\`\`
 
+## Preview Server Restart
+
+When you make changes that require the preview server to restart, output this marker:
+
+\`\`\`
+<restart-preview />
+\`\`\`
+
+**When to use:**
+- After modifying package.json or installing dependencies
+- After changing configuration files (next.config.js, tailwind.config.ts, etc.)
+- When hot-reload doesn't pick up changes
+
+The marker will automatically trigger a restart and won't be visible to the user.
+
 ## Checklist Before Responding
 
 - [ ] All files created with complete, runnable code


### PR DESCRIPTION
## Summary
- 에이전트가 `<restart-preview />` 마커를 출력하면 시스템이 자동으로 프리뷰 재시작
- 마커는 UI에서 필터링되어 사용자에게 보이지 않음
- 3초 디바운싱으로 중복 재시작 방지

## Changes
- `useChatStore.ts`: 마커 감지 및 필터링 로직 추가
- 시스템 프롬프트 3개 파일에 마커 사용법 안내 추가

## Test plan
- [ ] 프로젝트에서 에이전트에게 패키지 설치 요청
- [ ] 에이전트가 `<restart-preview />` 마커 출력하는지 확인
- [ ] 마커가 UI에 보이지 않는지 확인
- [ ] 프리뷰가 자동으로 재시작되는지 확인

Closes #25