### PR TITLE
fix: Prevent agent from using process control commands

### DIFF
--- a/apps/server/src/chat/prompts/fullstack-express-prompt.ts
+++ b/apps/server/src/chat/prompts/fullstack-express-prompt.ts
@@ -402,6 +402,7 @@ The marker will automatically trigger a restart and won't be visible to the user
 
 - **NEVER run \`npm run dev\`, \`npm start\`, or any server-starting commands** - The preview system handles this
 - **NEVER run long-running processes or commands that don't terminate**
+- **NEVER use process control commands** like \`kill\`, \`pkill\`, \`fuser -k\`, \`lsof\` to manage servers - Use \`<restart-preview />\` marker instead
 - Never use Python or non-Node.js backend code
 - Never skip database schema definition
 - Never hardcode API URLs (use environment variables)

--- a/apps/server/src/chat/prompts/fullstack-fastapi-prompt.ts
+++ b/apps/server/src/chat/prompts/fullstack-fastapi-prompt.ts
@@ -385,6 +385,7 @@ The marker will automatically trigger a restart and won't be visible to the user
 
 - **NEVER run \`uvicorn\`, \`npm run dev\`, \`npm start\`, or any server-starting commands** - The preview system handles this
 - **NEVER run long-running processes or commands that don't terminate**
+- **NEVER use process control commands** like \`kill\`, \`pkill\`, \`fuser -k\`, \`lsof\` to manage servers - Use \`<restart-preview />\` marker instead
 - Never use Node.js or non-Python backend code
 - Never skip database model definition
 - Never hardcode API URLs (use environment variables)

--- a/apps/server/src/chat/prompts/web-system-prompt.ts
+++ b/apps/server/src/chat/prompts/web-system-prompt.ts
@@ -261,6 +261,7 @@ The marker will automatically trigger a restart and won't be visible to the user
 
 - **NEVER run \`npm run dev\`, \`npm start\`, or any server-starting commands** - The preview system handles this automatically
 - **NEVER run long-running processes or commands that don't terminate**
+- **NEVER use process control commands** like \`kill\`, \`pkill\`, \`fuser -k\`, \`lsof\` to manage servers - Use \`<restart-preview />\` marker instead
 - Never create CLI tools or scripts
 - Never use inline styles (use Tailwind)
 - Never skip error handling


### PR DESCRIPTION
## Summary
- 에이전트가 `kill`, `pkill`, `fuser -k`, `lsof` 같은 프로세스 제어 명령어를 사용하지 못하도록 시스템 프롬프트에 명시적 금지 추가
- 대신 `<restart-preview />` 마커를 사용하도록 안내

## Changes
- `web-system-prompt.ts`: 프로세스 제어 명령어 금지 추가
- `fullstack-express-prompt.ts`: 프로세스 제어 명령어 금지 추가
- `fullstack-fastapi-prompt.ts`: 프로세스 제어 명령어 금지 추가

## Test plan
- [ ] 에이전트에게 서버 재시작 요청 시 마커를 사용하는지 확인
- [ ] `fuser -k` 같은 명령어를 사용하지 않는지 확인

Closes #28