### PR TITLE
fix: Escape quotes in TestRunner.tsx to fix build error

### DIFF
--- a/apps/web/src/components/testing/TestRunner.tsx
+++ b/apps/web/src/components/testing/TestRunner.tsx
@@ -427,7 +427,7 @@ export function TestRunner({ projectId }: TestRunnerProps) {
                         )}
                         {step.value && (
                           <span className="ml-2 text-sm text-muted-foreground">
-                            = "{step.value}"
+                            = &quot;{step.value}&quot;
                           </span>
                         )}
                       </div>


### PR DESCRIPTION
## Summary
- JSX에서 쌍따옴표(`"`)를 `&quot;`로 이스케이프하여 빌드 오류 수정
- `react/no-unescaped-entities` ESLint 에러 해결

## Test plan
- [x] `pnpm build` 성공 확인