### PR TITLE
feat: Add Prisma database setup to setup.sh

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,6 +3,7 @@
 # 프로젝트 초기 설정 스크립트
 # - Git hooks 설치
 # - .env 파일 생성
+# - Prisma 데이터베이스 설정
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -79,10 +80,46 @@ setup_env_files() {
 }
 
 # ===========================================
+# 3. Prisma 데이터베이스 설정
+# ===========================================
+setup_database() {
+    echo "📌 데이터베이스 설정 중..."
+
+    local server_dir="$ROOT_DIR/apps/server"
+
+    if [ ! -f "$server_dir/.env" ]; then
+        echo "   ⚠️  .env 파일이 없습니다. 데이터베이스 설정을 건너뜁니다."
+        return
+    fi
+
+    # pnpm이 설치되어 있는지 확인
+    if ! command -v pnpm &> /dev/null; then
+        echo "   ⚠️  pnpm이 설치되어 있지 않습니다. 데이터베이스 설정을 건너뜁니다."
+        return
+    fi
+
+    # Prisma 클라이언트 생성 및 DB 푸시
+    cd "$server_dir"
+    pnpm prisma generate > /dev/null 2>&1
+    pnpm prisma db push > /dev/null 2>&1
+
+    if [ $? -eq 0 ]; then
+        echo "   ✓ 데이터베이스 스키마 적용됨"
+    else
+        echo "   ⚠️  데이터베이스 설정 실패. 수동으로 'pnpm prisma db push'를 실행하세요."
+    fi
+
+    cd "$ROOT_DIR"
+    echo "   완료!"
+    echo ""
+}
+
+# ===========================================
 # 실행
 # ===========================================
 setup_git_hooks
 setup_env_files
+setup_database
 
 echo "=========================================="
 echo "  ✅ 초기 설정 완료!"


### PR DESCRIPTION
## Summary
- `setup.sh`에 Prisma 데이터베이스 자동 설정 추가
- `prisma generate` 및 `prisma db push` 자동 실행
- `.env` 파일 또는 pnpm이 없으면 건너뜀

## Test plan
- [x] `bash scripts/setup.sh` 실행 시 데이터베이스 스키마 적용 확인
- [x] `.env` 파일 없을 때 건너뛰기 확인

Closes #41