### PR TITLE
fix: Skip --dangerously-skip-permissions when running as root

### DIFF
--- a/apps/server/src/chat/claude-cli.service.ts
+++ b/apps/server/src/chat/claude-cli.service.ts
@@ -76,9 +76,15 @@ export class ClaudeCliService {
       // Build CLI command with optional resume flag and mode-specific tools
       const resumeFlag = resumeSessionId ? `--resume "${resumeSessionId}"` : "";
       const toolsFlag = mode === "ask" ? `--tools "${ASK_MODE_TOOLS.join(",")}"` : "";
-      const cliCommand = `${this.cliPath} -p "$(cat '${tempFile}')" ${resumeFlag} ${toolsFlag} --output-format stream-json --verbose --dangerously-skip-permissions`;
+      // Skip --dangerously-skip-permissions when running as root (not allowed for security)
+      const isRoot = process.getuid?.() === 0;
+      const permissionsFlag = isRoot ? "" : "--dangerously-skip-permissions";
+      const cliCommand = `${this.cliPath} -p "$(cat '${tempFile}')" ${resumeFlag} ${toolsFlag} --output-format stream-json --verbose ${permissionsFlag}`;
       const command = `script -q -c '${cliCommand}' /dev/null`;
 
+      if (isRoot) {
+        this.logger.warn("Running as root: --dangerously-skip-permissions disabled");
+      }
       if (mode === "ask") {
         this.logger.log(`Ask mode: restricting tools to ${ASK_MODE_TOOLS.join(", ")}`);
       }


### PR DESCRIPTION
## Summary
- root 환경 감지 시 `--dangerously-skip-permissions` 옵션 자동 제외
- `process.getuid()` 사용하여 root 권한 확인
- root일 때 경고 로그 출력

## Test plan
- [x] 타입 체크 통과
- [x] root 환경에서 서버 실행 시 해당 옵션 제외 확인

Closes #44