### PR TITLE
fix: Prevent Tailwind CSS version conflict between packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+public-hoist-pattern[]=!tailwindcss
+public-hoist-pattern[]=!@tailwindcss/*


### PR DESCRIPTION
## Summary
- `.npmrc` 파일 추가하여 Tailwind CSS hoisting 방지
- `docs/` 패키지(Tailwind v4)와 `apps/web/` 패키지(Tailwind v3) 간 버전 충돌 해결
- 빌드 시 발생하던 "PostCSS plugin has moved to a separate package" 에러 수정

## Test plan
- [x] `pnpm install` 성공 확인
- [x] `pnpm build --filter @claudeship/web` 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)