### PR TITLE
feat: Add conversational framework selection system

### DIFF
--- a/apps/server/src/project/dto/create-project.dto.ts
+++ b/apps/server/src/project/dto/create-project.dto.ts
@@ -1,8 +1,13 @@
-import { ProjectType, BackendFramework } from "@prisma/client";
+import {
+  AppType,
+  FrontendFramework,
+  BackendFramework,
+} from "@prisma/client";
 
 export class CreateProjectDto {
   name: string;
-  projectType: ProjectType;
+  appType: AppType;
+  frontendFramework?: FrontendFramework;
   backendFramework?: BackendFramework;
   description?: string;
 }

--- a/apps/server/src/project/project.service.ts
+++ b/apps/server/src/project/project.service.ts
@@ -71,11 +71,19 @@ export class ProjectService {
       await fs.mkdir(path.join(projectPath, "backend"), { recursive: true });
     }
 
+    // Derive deprecated projectType from appType
+    const projectType =
+      dto.appType === "MOBILE" || dto.appType === "MOBILE_WITH_API"
+        ? "NATIVE" as const
+        : "WEB" as const;
+
     // Create project in database first (to get ID)
     const project = await this.prisma.project.create({
       data: {
         name: dto.name,
-        projectType: dto.projectType,
+        appType: dto.appType,
+        projectType,
+        frontendFramework: dto.frontendFramework || "NONE",
         backendFramework: dto.backendFramework || "NONE",
         path: projectPath,
         description: dto.description,


### PR DESCRIPTION
## Summary
- 프로젝트 생성 시 대화형 프레임워크 선택 시스템 추가
- 프론트엔드/백엔드 프레임워크별 전용 프롬프트 템플릿 구현 (React, Next.js, Vue, Svelte, Flutter, Expo, React Native, Express, FastAPI, Django, NestJS)
- 채팅 중 프레임워크 변경 의도 감지 서비스 (`FrameworkDetectorService`) 추가
- 프레임워크별 시스템 프롬프트를 동적으로 빌드하는 `PromptBuilderService` 추가
- Project 스키마에 `appType`, `frontendFramework`, `backendFramework` 필드 추가
- `CreateProjectModal` UI 개선 (앱 타입 선택 → 프레임워크 선택 스텝 흐름)
- `ProjectCard` UI에 선택된 프레임워크 표시

## Test plan
- [x] `pnpm build` 성공 확인