### PR TITLE
fix: Isolate chat store state per project (#65)

### DIFF
--- a/apps/web/src/components/chat/ChatPanel.tsx
+++ b/apps/web/src/components/chat/ChatPanel.tsx
@@ -21,18 +21,18 @@ export function ChatPanel({ projectId }: ChatPanelProps) {
     isStreaming,
     streamingBlocks,
     messageQueue,
+    initForProject,
     fetchMessages,
     fetchActiveSession,
     sendMessage,
-    clearMessages,
   } = useChatStore();
 
   useEffect(() => {
-    clearMessages();
+    initForProject(projectId);
     fetchMessages(projectId);
     // Check for active session on mount
     fetchActiveSession(projectId);
-  }, [projectId, fetchMessages, fetchActiveSession, clearMessages]);
+  }, [projectId, initForProject, fetchMessages, fetchActiveSession]);
 
   // Note: We don't poll during streaming because the SSE stream is the source of truth.
   // fetchActiveSession is only called on mount (above) for page refresh recovery.


### PR DESCRIPTION
## Summary
- Add `currentProjectId` tracking to `useChatStore` to identify the active project
- Add `initForProject(projectId)` method for full state reset on project switch (preserves `mode` as user preference)
- Add stale response guards in `fetchMessages`, `fetchActiveSession`, and `sendMessage` to prevent previous project's responses from leaking into the current project
- Cancel in-flight SSE streams via `reader.cancel()` when the active project changes

Closes #65

## Test plan
- [x] `pnpm build` succeeded