### PR TITLE
feat: Add architect agent for automated code review

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -20,6 +20,7 @@
     "@nestjs/common": "^10.4.0",
     "@nestjs/config": "^3.3.0",
     "@nestjs/core": "^10.4.0",
+    "@nestjs/event-emitter": "^3.0.1",
     "@nestjs/platform-express": "^10.4.0",
     "@prisma/client": "^6.1.0",
     "chokidar": "^5.0.0",

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -28,6 +28,7 @@ model Project {
   updatedAt DateTime @updatedAt
 
   messages Message[]
+  reviews  Review[]
 
   @@map("projects")
 }
@@ -90,6 +91,32 @@ enum Role {
   USER
   ASSISTANT
   SYSTEM
+}
+
+enum ReviewStatus {
+  RUNNING
+  COMPLETED
+  FAILED
+  AUTO_FIXING
+}
+
+model Review {
+  id               String       @id @default(uuid())
+  projectId        String
+  status           ReviewStatus @default(RUNNING)
+  summary          String?
+  overallScore     Int?
+  issues           String?      @default("[]")  // JSON array of ReviewIssue
+  strengths        String?      @default("[]")  // JSON array of strings
+  recommendations  String?      @default("[]")  // JSON array of strings
+  cost             Float?
+  triggerMessageId String?
+  createdAt        DateTime     @default(now())
+  completedAt      DateTime?
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@map("reviews")
 }
 
 model Setting {

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
+import { EventEmitterModule } from "@nestjs/event-emitter";
 import { AppController } from "./app.controller";
 import { AppService } from "./app.service";
 import { PrismaModule } from "./prisma/prisma.module";
@@ -13,12 +14,14 @@ import { TestingModule } from "./testing/testing.module";
 import { CheckpointModule } from "./checkpoint/checkpoint.module";
 import { ProjectContextModule } from "./project-context/project-context.module";
 import { EnvModule } from "./env/env.module";
+import { ArchitectModule } from "./architect/architect.module";
 
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
     }),
+    EventEmitterModule.forRoot(),
     PrismaModule,
     ProjectModule,
     ChatModule,
@@ -30,6 +33,7 @@ import { EnvModule } from "./env/env.module";
     CheckpointModule,
     ProjectContextModule,
     EnvModule,
+    ArchitectModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/server/src/architect/architect.controller.ts
+++ b/apps/server/src/architect/architect.controller.ts
@@ -1,0 +1,67 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Sse,
+  Res,
+  MessageEvent,
+} from "@nestjs/common";
+import { Response } from "express";
+import { Observable, map, takeUntil, Subject, interval, merge } from "rxjs";
+import { ArchitectService, ReviewStreamEvent } from "./architect.service";
+
+@Controller("projects/:projectId/reviews")
+export class ArchitectController {
+  constructor(private readonly architectService: ArchitectService) {}
+
+  @Get()
+  getReviews(@Param("projectId") projectId: string) {
+    return this.architectService.getReviews(projectId);
+  }
+
+  @Get(":reviewId")
+  getReview(
+    @Param("projectId") projectId: string,
+    @Param("reviewId") reviewId: string,
+  ) {
+    return this.architectService.getReview(projectId, reviewId);
+  }
+
+  @Post("trigger")
+  triggerReview(@Param("projectId") projectId: string) {
+    return this.architectService.triggerReview(projectId);
+  }
+
+  @Sse("subscribe")
+  subscribeToReviews(
+    @Param("projectId") projectId: string,
+    @Res() res: Response,
+  ): Observable<MessageEvent> {
+    const closeSubject = new Subject<void>();
+
+    res.on("close", () => {
+      closeSubject.next();
+      closeSubject.complete();
+    });
+
+    // Heartbeat every 30 seconds
+    const heartbeat$ = interval(30000).pipe(
+      map(() => ({ data: { type: "heartbeat", timestamp: Date.now() } })),
+    );
+
+    // Review events
+    const events$ = this.architectService.getReviewStream(projectId).pipe(
+      map((event: ReviewStreamEvent) => ({
+        data: event,
+      })),
+    );
+
+    return merge(heartbeat$, events$).pipe(
+      takeUntil(closeSubject),
+      map(
+        (event) => ({ data: JSON.stringify(event.data) }) as MessageEvent,
+      ),
+    );
+  }
+}

--- a/apps/server/src/architect/architect.module.ts
+++ b/apps/server/src/architect/architect.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { ArchitectController } from "./architect.controller";
+import { ArchitectService } from "./architect.service";
+import { ProjectModule } from "../project/project.module";
+import { ChatModule } from "../chat/chat.module";
+
+@Module({
+  imports: [ProjectModule, ChatModule],
+  controllers: [ArchitectController],
+  providers: [ArchitectService],
+  exports: [ArchitectService],
+})
+export class ArchitectModule {}

--- a/apps/server/src/architect/architect.service.ts
+++ b/apps/server/src/architect/architect.service.ts
@@ -1,0 +1,389 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { OnEvent } from "@nestjs/event-emitter";
+import { Observable, Subject } from "rxjs";
+import { PrismaService } from "../prisma/prisma.service";
+import { ProjectService } from "../project/project.service";
+import { ClaudeCliService } from "../chat/claude-cli.service";
+import { ChatService } from "../chat/chat.service";
+import { Role, ReviewStatus } from "@prisma/client";
+import { randomUUID } from "crypto";
+import { buildReviewPrompt } from "./prompts/review-prompt";
+import type { ReviewResult, ReviewIssue } from "@claudeship/shared";
+
+export interface BuildCompleteEvent {
+  projectId: string;
+  messageId: string;
+  toolActivities: Array<{ name: string; input?: Record<string, unknown> }>;
+}
+
+export interface ReviewStreamEvent {
+  type: "start" | "progress" | "complete" | "error";
+  reviewId?: string;
+  data?: unknown;
+}
+
+// Tool names that indicate file modifications
+const FILE_MODIFY_TOOLS = ["Write", "Edit", "MultiEdit"];
+
+// Cooldown between reviews (30 seconds)
+const REVIEW_COOLDOWN_MS = 30_000;
+
+@Injectable()
+export class ArchitectService {
+  private readonly logger = new Logger(ArchitectService.name);
+  private reviewSubjects: Map<string, Subject<ReviewStreamEvent>> = new Map();
+  private lastReviewTime: Map<string, number> = new Map();
+
+  constructor(
+    private prisma: PrismaService,
+    private projectService: ProjectService,
+    private claudeCliService: ClaudeCliService,
+    private chatService: ChatService,
+  ) {}
+
+  @OnEvent("build.complete")
+  async handleBuildComplete(event: BuildCompleteEvent): Promise<void> {
+    const { projectId, messageId, toolActivities } = event;
+
+    // Only trigger review if file modifications occurred
+    const hasFileChanges = toolActivities.some((t) =>
+      FILE_MODIFY_TOOLS.includes(t.name),
+    );
+
+    if (!hasFileChanges) {
+      this.logger.log(
+        `Skipping review for project ${projectId}: no file modifications`,
+      );
+      return;
+    }
+
+    // Check cooldown
+    const lastReview = this.lastReviewTime.get(projectId) || 0;
+    if (Date.now() - lastReview < REVIEW_COOLDOWN_MS) {
+      this.logger.log(
+        `Skipping review for project ${projectId}: cooldown active`,
+      );
+      return;
+    }
+
+    // Check if already running
+    const runningReview = await this.prisma.review.findFirst({
+      where: { projectId, status: "RUNNING" },
+    });
+    if (runningReview) {
+      this.logger.log(
+        `Skipping review for project ${projectId}: review already running`,
+      );
+      return;
+    }
+
+    await this.triggerReview(projectId, messageId);
+  }
+
+  async triggerReview(
+    projectId: string,
+    triggerMessageId?: string,
+  ): Promise<{ reviewId: string }> {
+    const project = await this.prisma.project.findUnique({
+      where: { id: projectId },
+    });
+
+    if (!project) {
+      throw new Error("Project not found");
+    }
+
+    const projectPath = await this.projectService.getProjectPath(projectId);
+
+    // Create review record
+    const review = await this.prisma.review.create({
+      data: {
+        projectId,
+        status: "RUNNING",
+        triggerMessageId,
+      },
+    });
+
+    this.lastReviewTime.set(projectId, Date.now());
+    this.emitReviewEvent(projectId, {
+      type: "start",
+      reviewId: review.id,
+    });
+
+    // Run review asynchronously
+    this.runReview(review.id, projectId, projectPath).catch((err) => {
+      this.logger.error(`Review failed: ${err.message}`);
+    });
+
+    return { reviewId: review.id };
+  }
+
+  private async runReview(
+    reviewId: string,
+    projectId: string,
+    projectPath: string,
+  ): Promise<void> {
+    const sessionId = randomUUID();
+    const prompt = buildReviewPrompt(projectPath);
+
+    let fullResponse = "";
+    let totalCost = 0;
+
+    return new Promise<void>((resolve, reject) => {
+      const cliStream = this.claudeCliService.executePrompt(
+        projectPath,
+        prompt,
+        sessionId,
+        undefined,
+        "ask",
+      );
+
+      cliStream.subscribe({
+        next: (event) => {
+          if (event.type === "text" && event.content) {
+            fullResponse += event.content;
+          }
+          if (event.type === "complete" && event.cost) {
+            totalCost = event.cost;
+          }
+        },
+        error: async (error) => {
+          this.logger.error(`Review CLI error: ${error.message}`);
+          await this.prisma.review.update({
+            where: { id: reviewId },
+            data: {
+              status: "FAILED",
+              summary: error.message,
+              completedAt: new Date(),
+            },
+          });
+          this.emitReviewEvent(projectId, {
+            type: "error",
+            reviewId,
+            data: { error: error.message },
+          });
+          reject(error);
+        },
+        complete: async () => {
+          try {
+            const result = this.parseReviewResult(fullResponse);
+
+            await this.prisma.review.update({
+              where: { id: reviewId },
+              data: {
+                status: "COMPLETED",
+                summary: result.summary,
+                overallScore: result.overallScore,
+                issues: JSON.stringify(result.issues),
+                strengths: JSON.stringify(result.strengths),
+                recommendations: JSON.stringify(result.recommendations),
+                cost: totalCost,
+                completedAt: new Date(),
+              },
+            });
+
+            // Save summary as SYSTEM message in chat
+            const issueCount = result.issues.length;
+            const criticalCount = result.issues.filter(
+              (i) => i.severity === "critical",
+            ).length;
+            const highCount = result.issues.filter(
+              (i) => i.severity === "high",
+            ).length;
+
+            let summaryContent = `Code Review Complete - Score: ${result.overallScore}/100\n${result.summary}`;
+            if (issueCount > 0) {
+              summaryContent += `\n\nIssues: ${issueCount} total`;
+              if (criticalCount > 0)
+                summaryContent += ` (${criticalCount} critical)`;
+              if (highCount > 0) summaryContent += ` (${highCount} high)`;
+            }
+
+            await this.prisma.message.create({
+              data: {
+                projectId,
+                role: Role.SYSTEM,
+                content: summaryContent,
+                metadata: JSON.stringify({
+                  type: "review_summary",
+                  reviewId,
+                  overallScore: result.overallScore,
+                  issueCount,
+                  criticalCount,
+                  highCount,
+                }),
+              },
+            });
+
+            this.emitReviewEvent(projectId, {
+              type: "complete",
+              reviewId,
+              data: result,
+            });
+
+            // Auto-fix critical + autoFixable issues
+            const autoFixIssues = result.issues.filter(
+              (i) =>
+                (i.severity === "critical" || i.severity === "high") &&
+                i.autoFixable,
+            );
+
+            if (autoFixIssues.length > 0) {
+              await this.triggerAutoFix(projectId, reviewId, autoFixIssues);
+            }
+
+            resolve();
+          } catch (err) {
+            this.logger.error(`Failed to parse review result: ${err}`);
+            await this.prisma.review.update({
+              where: { id: reviewId },
+              data: {
+                status: "FAILED",
+                summary: "Failed to parse review result",
+                completedAt: new Date(),
+              },
+            });
+            this.emitReviewEvent(projectId, {
+              type: "error",
+              reviewId,
+              data: { error: "Failed to parse review result" },
+            });
+            reject(err);
+          }
+        },
+      });
+    });
+  }
+
+  private async triggerAutoFix(
+    projectId: string,
+    reviewId: string,
+    issues: ReviewIssue[],
+  ): Promise<void> {
+    this.logger.log(
+      `Triggering auto-fix for ${issues.length} issues in project ${projectId}`,
+    );
+
+    await this.prisma.review.update({
+      where: { id: reviewId },
+      data: { status: "AUTO_FIXING" },
+    });
+
+    const fixPrompt = this.buildAutoFixPrompt(issues);
+
+    // Send as a build message through ChatService
+    this.chatService.sendMessage(projectId, fixPrompt, "build").subscribe({
+      complete: async () => {
+        this.logger.log(`Auto-fix completed for review ${reviewId}`);
+        await this.prisma.review.update({
+          where: { id: reviewId },
+          data: { status: "COMPLETED" },
+        });
+      },
+      error: (err) => {
+        this.logger.error(`Auto-fix failed: ${err.message}`);
+      },
+    });
+  }
+
+  private buildAutoFixPrompt(issues: ReviewIssue[]): string {
+    const issueDescriptions = issues
+      .map((issue, i) => {
+        let desc = `${i + 1}. [${issue.severity.toUpperCase()}] ${issue.title}`;
+        if (issue.file) desc += `\n   File: ${issue.file}`;
+        if (issue.line) desc += `:${issue.line}`;
+        desc += `\n   ${issue.description}`;
+        if (issue.suggestion) desc += `\n   Suggestion: ${issue.suggestion}`;
+        return desc;
+      })
+      .join("\n\n");
+
+    return `[Architect Review - Auto Fix Request]
+
+The code review found the following critical/high severity issues that need to be fixed:
+
+${issueDescriptions}
+
+Please fix ALL of the above issues. For each fix:
+1. Read the relevant file
+2. Apply the minimal necessary change
+3. Do not introduce new features or refactor beyond what's needed`;
+  }
+
+  private parseReviewResult(raw: string): ReviewResult {
+    // Try to extract JSON from the response
+    let jsonStr = raw.trim();
+
+    // Try to find JSON in code fences
+    const fenceMatch = jsonStr.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
+    if (fenceMatch) {
+      jsonStr = fenceMatch[1].trim();
+    }
+
+    // Try to find JSON object
+    const jsonMatch = jsonStr.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      jsonStr = jsonMatch[0];
+    }
+
+    const parsed = JSON.parse(jsonStr);
+
+    return {
+      summary: parsed.summary || "Review completed",
+      overallScore: Math.max(0, Math.min(100, parsed.overallScore || 0)),
+      issues: Array.isArray(parsed.issues) ? parsed.issues : [],
+      strengths: Array.isArray(parsed.strengths) ? parsed.strengths : [],
+      recommendations: Array.isArray(parsed.recommendations)
+        ? parsed.recommendations
+        : [],
+    };
+  }
+
+  async getReviews(projectId: string) {
+    const reviews = await this.prisma.review.findMany({
+      where: { projectId },
+      orderBy: { createdAt: "desc" },
+      take: 20,
+    });
+
+    return reviews.map((r) => ({
+      ...r,
+      issues: JSON.parse(r.issues || "[]"),
+      strengths: JSON.parse(r.strengths || "[]"),
+      recommendations: JSON.parse(r.recommendations || "[]"),
+    }));
+  }
+
+  async getReview(projectId: string, reviewId: string) {
+    const review = await this.prisma.review.findFirst({
+      where: { id: reviewId, projectId },
+    });
+
+    if (!review) {
+      throw new Error("Review not found");
+    }
+
+    return {
+      ...review,
+      issues: JSON.parse(review.issues || "[]"),
+      strengths: JSON.parse(review.strengths || "[]"),
+      recommendations: JSON.parse(review.recommendations || "[]"),
+    };
+  }
+
+  getReviewStream(projectId: string): Observable<ReviewStreamEvent> {
+    if (!this.reviewSubjects.has(projectId)) {
+      this.reviewSubjects.set(projectId, new Subject<ReviewStreamEvent>());
+    }
+    return this.reviewSubjects.get(projectId)!.asObservable();
+  }
+
+  private emitReviewEvent(
+    projectId: string,
+    event: ReviewStreamEvent,
+  ): void {
+    const subject = this.reviewSubjects.get(projectId);
+    if (subject) {
+      subject.next(event);
+    }
+  }
+}

--- a/apps/server/src/architect/prompts/review-prompt.ts
+++ b/apps/server/src/architect/prompts/review-prompt.ts
@@ -1,0 +1,66 @@
+/**
+ * Review prompt builder for the Architect agent.
+ * Generates a system prompt that instructs Claude to review code changes
+ * and return structured JSON output.
+ */
+
+export function buildReviewPrompt(projectPath: string): string {
+  return `You are a senior code reviewer. Analyze the recent code changes in the project at "${projectPath}".
+
+## Review Categories
+
+1. **Security** - Vulnerabilities, injection risks, auth issues, exposed secrets
+2. **Bug** - Logic errors, edge cases, null references, race conditions
+3. **Architecture** - Design patterns, modularity, coupling, SOLID violations
+4. **Performance** - N+1 queries, memory leaks, unnecessary computation, bundle size
+5. **Quality** - Naming, readability, duplication, missing error handling
+
+## Instructions
+
+1. Read the recently modified files using the Read tool
+2. Analyze the code for issues across all categories
+3. Identify strengths and positive patterns
+4. Provide actionable recommendations
+
+## Output Format
+
+You MUST respond with ONLY a valid JSON object (no markdown, no code fences, no explanation before/after). The JSON must follow this exact schema:
+
+{
+  "summary": "Brief 1-2 sentence summary of the review",
+  "overallScore": 85,
+  "issues": [
+    {
+      "severity": "critical|high|medium|low",
+      "category": "security|bug|architecture|performance|quality",
+      "title": "Short issue title",
+      "description": "Detailed description of the issue",
+      "file": "relative/path/to/file.ts",
+      "line": 42,
+      "suggestion": "How to fix this issue",
+      "autoFixable": true
+    }
+  ],
+  "strengths": [
+    "Positive aspect of the code"
+  ],
+  "recommendations": [
+    "Actionable recommendation for improvement"
+  ]
+}
+
+## Scoring Guide
+
+- 90-100: Excellent - minimal or no issues
+- 70-89: Good - minor issues only
+- 50-69: Needs improvement - some significant issues
+- 0-49: Critical - major issues requiring immediate attention
+
+## Rules
+
+- Be specific: reference actual file paths and line numbers
+- Be constructive: always suggest how to fix issues
+- Mark "autoFixable": true only for issues that can be fixed with simple, safe code changes
+- Only mark critical/high severity for genuinely important issues
+- If the code is well-written, say so - don't invent issues`;
+}

--- a/apps/web/src/components/architect/ArchitectPanel.tsx
+++ b/apps/web/src/components/architect/ArchitectPanel.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useArchitectStore } from "@/stores/useArchitectStore";
+import { IssueCard } from "./IssueCard";
+import {
+  Search,
+  RefreshCw,
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  Sparkles,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { ReviewIssue } from "@claudeship/shared";
+
+interface ArchitectPanelProps {
+  projectId: string;
+}
+
+function ScoreBadge({ score }: { score: number }) {
+  let color = "text-green-600 bg-green-100";
+  if (score < 50) color = "text-red-600 bg-red-100";
+  else if (score < 70) color = "text-yellow-600 bg-yellow-100";
+  else if (score < 90) color = "text-blue-600 bg-blue-100";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center px-2 py-0.5 rounded-full text-sm font-bold",
+        color,
+      )}
+    >
+      {score}
+    </span>
+  );
+}
+
+function StatusIcon({ status }: { status: string }) {
+  switch (status) {
+    case "COMPLETED":
+      return <CheckCircle2 className="h-4 w-4 text-green-600" />;
+    case "FAILED":
+      return <XCircle className="h-4 w-4 text-red-600" />;
+    case "RUNNING":
+      return <Loader2 className="h-4 w-4 text-blue-600 animate-spin" />;
+    case "AUTO_FIXING":
+      return <Sparkles className="h-4 w-4 text-purple-600 animate-pulse" />;
+    default:
+      return null;
+  }
+}
+
+export function ArchitectPanel({ projectId }: ArchitectPanelProps) {
+  const {
+    reviews,
+    activeReview,
+    isReviewing,
+    error,
+    fetchReviews,
+    fetchReview,
+    triggerReview,
+    subscribeToReviews,
+    clearError,
+  } = useArchitectStore();
+
+  const [selectedReviewId, setSelectedReviewId] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchReviews(projectId);
+    const unsubscribe = subscribeToReviews(projectId);
+    return unsubscribe;
+  }, [projectId]);
+
+  useEffect(() => {
+    if (selectedReviewId) {
+      fetchReview(projectId, selectedReviewId);
+    }
+  }, [selectedReviewId, projectId]);
+
+  // Auto-select the latest review
+  useEffect(() => {
+    if (reviews.length > 0 && !selectedReviewId) {
+      setSelectedReviewId(reviews[0].id);
+    }
+  }, [reviews]);
+
+  const handleTriggerReview = () => {
+    triggerReview(projectId);
+  };
+
+  const selectedReview = activeReview?.id === selectedReviewId ? activeReview : null;
+
+  const groupedIssues: Record<string, ReviewIssue[]> = {};
+  if (selectedReview?.issues) {
+    for (const issue of selectedReview.issues) {
+      if (!groupedIssues[issue.severity]) {
+        groupedIssues[issue.severity] = [];
+      }
+      groupedIssues[issue.severity].push(issue);
+    }
+  }
+
+  const severityOrder = ["critical", "high", "medium", "low"];
+
+  return (
+    <div className="flex h-full">
+      {/* Left sidebar - review list */}
+      <div className="w-56 border-r flex flex-col flex-shrink-0">
+        <div className="p-3 border-b flex items-center justify-between">
+          <h3 className="font-medium text-sm">Reviews</h3>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleTriggerReview}
+            disabled={isReviewing}
+            className="h-7 text-xs"
+          >
+            {isReviewing ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <RefreshCw className="h-3 w-3" />
+            )}
+          </Button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto">
+          {reviews.length === 0 ? (
+            <div className="p-4 text-center text-sm text-muted-foreground">
+              No reviews yet.
+              <br />
+              Reviews run automatically after builds.
+            </div>
+          ) : (
+            reviews.map((review) => (
+              <button
+                key={review.id}
+                onClick={() => setSelectedReviewId(review.id)}
+                className={cn(
+                  "w-full text-left p-3 border-b hover:bg-muted/50 transition-colors",
+                  selectedReviewId === review.id && "bg-muted",
+                )}
+              >
+                <div className="flex items-center gap-2 mb-1">
+                  <StatusIcon status={review.status} />
+                  {review.overallScore != null && (
+                    <ScoreBadge score={review.overallScore} />
+                  )}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {new Date(review.createdAt).toLocaleString()}
+                </div>
+                {review.issues.length > 0 && (
+                  <div className="text-xs text-muted-foreground mt-1">
+                    {review.issues.length} issue
+                    {review.issues.length !== 1 ? "s" : ""}
+                  </div>
+                )}
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Right content - review detail */}
+      <div className="flex-1 overflow-y-auto">
+        {!selectedReview ? (
+          <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
+            <Search className="h-12 w-12 mb-4 opacity-50" />
+            <p className="text-sm">Select a review to view details</p>
+            {reviews.length === 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleTriggerReview}
+                disabled={isReviewing}
+                className="mt-4"
+              >
+                {isReviewing ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Reviewing...
+                  </>
+                ) : (
+                  "Trigger Manual Review"
+                )}
+              </Button>
+            )}
+          </div>
+        ) : (
+          <div className="p-4 space-y-4">
+            {/* Header */}
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <StatusIcon status={selectedReview.status} />
+                {selectedReview.overallScore != null && (
+                  <div className="flex items-center gap-2">
+                    <span className="text-2xl font-bold">
+                      {selectedReview.overallScore}
+                    </span>
+                    <span className="text-sm text-muted-foreground">/ 100</span>
+                  </div>
+                )}
+              </div>
+              {selectedReview.cost != null && (
+                <span className="text-xs text-muted-foreground">
+                  Cost: ${selectedReview.cost.toFixed(4)}
+                </span>
+              )}
+            </div>
+
+            {/* Summary */}
+            {selectedReview.summary && (
+              <p className="text-sm text-muted-foreground border-l-2 pl-3">
+                {selectedReview.summary}
+              </p>
+            )}
+
+            {/* Issues */}
+            {selectedReview.issues.length > 0 && (
+              <div className="space-y-3">
+                <h4 className="font-medium text-sm flex items-center gap-2">
+                  <AlertTriangle className="h-4 w-4" />
+                  Issues ({selectedReview.issues.length})
+                </h4>
+                {severityOrder.map((severity) =>
+                  groupedIssues[severity]?.length ? (
+                    <div key={severity} className="space-y-2">
+                      <h5 className="text-xs font-medium text-muted-foreground uppercase">
+                        {severity} ({groupedIssues[severity].length})
+                      </h5>
+                      {groupedIssues[severity].map((issue, idx) => (
+                        <IssueCard key={`${severity}-${idx}`} issue={issue} />
+                      ))}
+                    </div>
+                  ) : null,
+                )}
+              </div>
+            )}
+
+            {/* Strengths */}
+            {selectedReview.strengths.length > 0 && (
+              <div className="space-y-2">
+                <h4 className="font-medium text-sm flex items-center gap-2">
+                  <CheckCircle2 className="h-4 w-4 text-green-600" />
+                  Strengths
+                </h4>
+                <ul className="space-y-1">
+                  {selectedReview.strengths.map((s, i) => (
+                    <li
+                      key={i}
+                      className="text-sm text-muted-foreground flex items-start gap-2"
+                    >
+                      <span className="text-green-600 mt-0.5">+</span>
+                      {s}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {/* Recommendations */}
+            {selectedReview.recommendations.length > 0 && (
+              <div className="space-y-2">
+                <h4 className="font-medium text-sm">Recommendations</h4>
+                <ul className="space-y-1">
+                  {selectedReview.recommendations.map((r, i) => (
+                    <li
+                      key={i}
+                      className="text-sm text-muted-foreground flex items-start gap-2"
+                    >
+                      <span className="text-blue-600 mt-0.5">-</span>
+                      {r}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+
+        {error && (
+          <div className="p-4">
+            <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-700">
+              {error}
+              <button
+                onClick={clearError}
+                className="ml-2 underline text-xs"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/architect/IssueCard.tsx
+++ b/apps/web/src/components/architect/IssueCard.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { ReviewIssue } from "@claudeship/shared";
+import {
+  ShieldAlert,
+  Bug,
+  Layers,
+  Gauge,
+  Code2,
+  FileCode,
+} from "lucide-react";
+
+interface IssueCardProps {
+  issue: ReviewIssue;
+}
+
+const severityConfig: Record<
+  string,
+  { color: string; bg: string; label: string }
+> = {
+  critical: { color: "text-red-600", bg: "bg-red-100", label: "Critical" },
+  high: { color: "text-orange-600", bg: "bg-orange-100", label: "High" },
+  medium: { color: "text-yellow-600", bg: "bg-yellow-100", label: "Medium" },
+  low: { color: "text-blue-600", bg: "bg-blue-100", label: "Low" },
+};
+
+const categoryIcons: Record<string, React.ReactNode> = {
+  security: <ShieldAlert className="h-3.5 w-3.5" />,
+  bug: <Bug className="h-3.5 w-3.5" />,
+  architecture: <Layers className="h-3.5 w-3.5" />,
+  performance: <Gauge className="h-3.5 w-3.5" />,
+  quality: <Code2 className="h-3.5 w-3.5" />,
+};
+
+export function IssueCard({ issue }: IssueCardProps) {
+  const severity = severityConfig[issue.severity] || severityConfig.low;
+
+  return (
+    <div className="border rounded-lg p-3 space-y-2 bg-background">
+      <div className="flex items-start gap-2">
+        <span
+          className={cn(
+            "inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium",
+            severity.bg,
+            severity.color,
+          )}
+        >
+          {severity.label}
+        </span>
+        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+          {categoryIcons[issue.category]}
+          {issue.category}
+        </span>
+        {issue.autoFixable && (
+          <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">
+            Auto-fixable
+          </span>
+        )}
+      </div>
+
+      <h4 className="font-medium text-sm">{issue.title}</h4>
+      <p className="text-sm text-muted-foreground">{issue.description}</p>
+
+      {issue.file && (
+        <div className="flex items-center gap-1 text-xs text-muted-foreground">
+          <FileCode className="h-3 w-3" />
+          <span className="font-mono">
+            {issue.file}
+            {issue.line ? `:${issue.line}` : ""}
+          </span>
+        </div>
+      )}
+
+      {issue.suggestion && (
+        <div className="bg-muted/50 rounded p-2 text-xs">
+          <span className="font-medium">Suggestion: </span>
+          {issue.suggestion}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/workspace/WorkspaceLayout.tsx
+++ b/apps/web/src/components/workspace/WorkspaceLayout.tsx
@@ -9,6 +9,7 @@ import { DatabasePanel } from "@/components/database/DatabasePanel";
 import { TestRunner } from "@/components/testing/TestRunner";
 import { CheckpointPanel } from "@/components/checkpoint/CheckpointPanel";
 import { EnvPanel } from "@/components/env/EnvPanel";
+import { ArchitectPanel } from "@/components/architect/ArchitectPanel";
 import {
   FolderTree,
   X,
@@ -17,6 +18,7 @@ import {
   FlaskConical,
   GitBranch,
   Settings2,
+  Search,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useTranslation } from "@/lib/i18n";
@@ -31,12 +33,13 @@ interface SelectedFile {
   extension: string;
 }
 
-type RightPanelTab = "preview" | "database" | "testing" | "checkpoint" | "env";
+type RightPanelTab = "preview" | "database" | "testing" | "checkpoint" | "env" | "review";
 
 const tabConfig: { id: RightPanelTab; icon: React.ReactNode; label: string }[] = [
   { id: "preview", icon: <Eye className="h-4 w-4" />, label: "Preview" },
   { id: "database", icon: <Database className="h-4 w-4" />, label: "Database" },
   { id: "testing", icon: <FlaskConical className="h-4 w-4" />, label: "Testing" },
+  { id: "review", icon: <Search className="h-4 w-4" />, label: "Review" },
   { id: "checkpoint", icon: <GitBranch className="h-4 w-4" />, label: "Checkpoint" },
   { id: "env", icon: <Settings2 className="h-4 w-4" />, label: "Env" },
 ];
@@ -68,6 +71,8 @@ export function WorkspaceLayout({ projectId }: WorkspaceLayoutProps) {
         return <CheckpointPanel projectId={projectId} />;
       case "env":
         return <EnvPanel projectId={projectId} />;
+      case "review":
+        return <ArchitectPanel projectId={projectId} />;
       default:
         return <PreviewPanel projectId={projectId} />;
     }

--- a/apps/web/src/stores/useArchitectStore.ts
+++ b/apps/web/src/stores/useArchitectStore.ts
@@ -1,0 +1,106 @@
+import { create } from "zustand";
+import { api } from "@/lib/api";
+import type { Review } from "@claudeship/shared";
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:14000/api";
+
+interface ArchitectState {
+  reviews: Review[];
+  activeReview: Review | null;
+  isReviewing: boolean;
+  error: string | null;
+  currentProjectId: string | null;
+
+  fetchReviews: (projectId: string) => Promise<void>;
+  fetchReview: (projectId: string, reviewId: string) => Promise<void>;
+  triggerReview: (projectId: string) => Promise<void>;
+  subscribeToReviews: (projectId: string) => () => void;
+  clearError: () => void;
+}
+
+export const useArchitectStore = create<ArchitectState>((set, get) => ({
+  reviews: [],
+  activeReview: null,
+  isReviewing: false,
+  error: null,
+  currentProjectId: null,
+
+  fetchReviews: async (projectId: string) => {
+    try {
+      const reviews = await api.get<Review[]>(
+        `/projects/${projectId}/reviews`,
+      );
+      set({ reviews, currentProjectId: projectId, error: null });
+    } catch (error) {
+      set({
+        error:
+          error instanceof Error ? error.message : "Failed to fetch reviews",
+      });
+    }
+  },
+
+  fetchReview: async (projectId: string, reviewId: string) => {
+    try {
+      const review = await api.get<Review>(
+        `/projects/${projectId}/reviews/${reviewId}`,
+      );
+      set({ activeReview: review, error: null });
+    } catch (error) {
+      set({
+        error:
+          error instanceof Error ? error.message : "Failed to fetch review",
+      });
+    }
+  },
+
+  triggerReview: async (projectId: string) => {
+    try {
+      set({ isReviewing: true, error: null });
+      await api.post(`/projects/${projectId}/reviews/trigger`);
+    } catch (error) {
+      set({
+        error:
+          error instanceof Error ? error.message : "Failed to trigger review",
+        isReviewing: false,
+      });
+    }
+  },
+
+  subscribeToReviews: (projectId: string) => {
+    const eventSource = new EventSource(
+      `${API_BASE_URL}/projects/${projectId}/reviews/subscribe`,
+    );
+
+    eventSource.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+
+        if (data.type === "start") {
+          set({ isReviewing: true });
+        } else if (data.type === "complete") {
+          set({ isReviewing: false });
+          // Refresh reviews list
+          get().fetchReviews(projectId);
+        } else if (data.type === "error") {
+          set({
+            isReviewing: false,
+            error: data.data?.error || "Review failed",
+          });
+        }
+      } catch {
+        // Ignore parse errors
+      }
+    };
+
+    eventSource.onerror = () => {
+      // EventSource will auto-reconnect
+    };
+
+    return () => {
+      eventSource.close();
+    };
+  },
+
+  clearError: () => set({ error: null }),
+}));

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,3 +2,4 @@ export * from "./types/project";
 export * from "./types/chat";
 export * from "./types/preview";
 export * from "./types/tech-stack";
+export * from "./types/review";

--- a/packages/shared/src/types/review.ts
+++ b/packages/shared/src/types/review.ts
@@ -1,0 +1,42 @@
+export type ReviewStatus = "RUNNING" | "COMPLETED" | "FAILED" | "AUTO_FIXING";
+export type IssueSeverity = "critical" | "high" | "medium" | "low";
+export type IssueCategory =
+  | "security"
+  | "bug"
+  | "architecture"
+  | "performance"
+  | "quality";
+
+export interface ReviewIssue {
+  severity: IssueSeverity;
+  category: IssueCategory;
+  title: string;
+  description: string;
+  file?: string;
+  line?: number;
+  suggestion?: string;
+  autoFixable?: boolean;
+}
+
+export interface ReviewResult {
+  summary: string;
+  overallScore: number;
+  issues: ReviewIssue[];
+  strengths: string[];
+  recommendations: string[];
+}
+
+export interface Review {
+  id: string;
+  projectId: string;
+  status: ReviewStatus;
+  summary?: string;
+  overallScore?: number;
+  issues: ReviewIssue[];
+  strengths: string[];
+  recommendations: string[];
+  cost?: number;
+  triggerMessageId?: string;
+  createdAt: string;
+  completedAt?: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       '@nestjs/core':
         specifier: ^10.4.0
         version: 10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/event-emitter':
+        specifier: ^3.0.1
+        version: 3.0.1(@nestjs/common@10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)
       '@nestjs/platform-express':
         specifier: ^10.4.0
         version: 10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)
@@ -724,6 +727,12 @@ packages:
         optional: true
       '@nestjs/websockets':
         optional: true
+
+  '@nestjs/event-emitter@3.0.1':
+    resolution: {integrity: sha512-0Ln/x+7xkU6AJFOcQI9tIhUMXVF7D5itiaQGOyJbXtlAfAIt8gzDdJm+Im7cFzKoWkiW5nCXCPh6GSvdQd/3Dw==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
 
   '@nestjs/platform-express@10.4.20':
     resolution: {integrity: sha512-rh97mX3rimyf4xLMLHuTOBKe6UD8LOJ14VlJ1F/PTd6C6ZK9Ak6EHuJvdaGcSFQhd3ZMBh3I6CuujKGW9pNdIg==}
@@ -2716,6 +2725,9 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  eventemitter2@6.4.9:
+    resolution: {integrity: sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==}
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
@@ -5667,6 +5679,12 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@nestjs/event-emitter@3.0.1(@nestjs/common@10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)':
+    dependencies:
+      '@nestjs/common': 10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      eventemitter2: 6.4.9
+
   '@nestjs/platform-express@10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)':
     dependencies:
       '@nestjs/common': 10.4.20(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -7956,6 +7974,8 @@ snapshots:
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
+
+  eventemitter2@6.4.9: {}
 
   eventemitter3@4.0.7: {}
 


### PR DESCRIPTION
## Summary
- 빌드 완료 시 자동으로 코드 리뷰를 실행하는 아키텍트 에이전트 추가
- EventEmitter2 기반 `build.complete` 이벤트로 ChatService와 ArchitectService 디커플링
- Review 탭에서 리뷰 결과 확인 (점수, 이슈, 강점, 권장사항)
- 채팅에 리뷰 요약 시스템 메시지 자동 표시
- critical/high + autoFixable 이슈 자동 수정 요청 지원

## Test plan
- [x] `pnpm build` 성공 확인
- [x] 서버 시작 후 ArchitectController 라우트 4개 정상 등록 확인
- [x] `POST /projects/:id/reviews/trigger` 수동 리뷰 트리거 → Claude CLI ask 모드 실행 → Review COMPLETED 확인
- [x] `GET /projects/:id/reviews` 리뷰 목록 정상 반환 확인
- [x] SYSTEM 메시지에 review_summary 메타데이터 포함하여 저장 확인

Closes #68