### PR TITLE
fix: Use --permission-mode acceptEdits for root environment

### DIFF
--- a/apps/server/src/chat/claude-cli.service.ts
+++ b/apps/server/src/chat/claude-cli.service.ts
@@ -76,9 +76,9 @@ export class ClaudeCliService {
       // Build CLI command with optional resume flag and mode-specific tools
       const resumeFlag = resumeSessionId ? `--resume "${resumeSessionId}"` : "";
       const toolsFlag = mode === "ask" ? `--tools "${ASK_MODE_TOOLS.join(",")}"` : "";
-      // Skip --dangerously-skip-permissions when running as root (not allowed for security)
+      // Root cannot use --dangerously-skip-permissions; use --permission-mode acceptEdits instead
       const isRoot = process.getuid?.() === 0;
-      const permissionsFlag = isRoot ? "" : "--dangerously-skip-permissions";
+      const permissionsFlag = isRoot ? "--permission-mode acceptEdits" : "--dangerously-skip-permissions";
       const cliCommand = `${this.cliPath} -p "$(cat '${tempFile}')" ${resumeFlag} ${toolsFlag} --output-format stream-json --verbose ${permissionsFlag}`;
       const command = `script -q -c '${cliCommand}' /dev/null`;
 


### PR DESCRIPTION
## Summary
- root 환경에서 build 모드 시 "파일 쓰기 권한을 허용해 주셔야 합니다" 메시지가 표시되는 버그 수정
- Claude CLI가 root에서 `--dangerously-skip-permissions`를 거부하므로, `--permission-mode acceptEdits`를 대신 사용

## Test plan
- [x] `pnpm build` 성공 확인
- [x] root 환경에서 `claude -p "say hello" --permission-mode acceptEdits --output-format stream-json --verbose` 정상 동작 확인

Closes #71