### PR TITLE
fix: Use --permission-mode dontAsk for root to bypass all tool permissions

### DIFF
--- a/apps/server/src/chat/claude-cli.service.ts
+++ b/apps/server/src/chat/claude-cli.service.ts
@@ -76,9 +76,9 @@ export class ClaudeCliService {
       // Build CLI command with optional resume flag and mode-specific tools
       const resumeFlag = resumeSessionId ? `--resume "${resumeSessionId}"` : "";
       const toolsFlag = mode === "ask" ? `--tools "${ASK_MODE_TOOLS.join(",")}"` : "";
-      // Root cannot use --dangerously-skip-permissions; use --permission-mode acceptEdits instead
+      // Root cannot use --dangerously-skip-permissions; use --permission-mode dontAsk instead
       const isRoot = process.getuid?.() === 0;
-      const permissionsFlag = isRoot ? "--permission-mode acceptEdits" : "--dangerously-skip-permissions";
+      const permissionsFlag = isRoot ? "--permission-mode dontAsk" : "--dangerously-skip-permissions";
       const cliCommand = `${this.cliPath} -p "$(cat '${tempFile}')" ${resumeFlag} ${toolsFlag} --output-format stream-json --verbose ${permissionsFlag}`;
       const command = `script -q -c '${cliCommand}' /dev/null`;
 


### PR DESCRIPTION
## Summary
- `--permission-mode acceptEdits` only auto-accepts Edit/Write tools, leaving other tools (Bash, Read, etc.) still prompting for permissions
- Changed to `--permission-mode dontAsk` which skips all permission prompts when running as root

Fixes #71

## Test plan
- [x] `claude -p "say hello" --permission-mode dontAsk` works as root
- [x] `claude -p "Read file..." --permission-mode dontAsk --output-format stream-json --verbose` completes with `permission_denials: []`
- [x] Server build succeeds