### PR TITLE
fix: Add entryFile to nest-cli.json for correct dist path

### DIFF
--- a/apps/server/nest-cli.json
+++ b/apps/server/nest-cli.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/nest-cli",
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
+  "entryFile": "apps/server/src/main",
   "compilerOptions": {
     "deleteOutDir": true
   }


### PR DESCRIPTION
## Summary
- `nest start` fails with `MODULE_NOT_FOUND` because tsconfig `paths` (shared package reference) causes tsc to output `dist/apps/server/src/main.js` instead of `dist/main.js`
- Added `entryFile: "apps/server/src/main"` to `nest-cli.json` so NestJS resolves the correct entry point

## Test plan
- [x] `pnpm --filter @claudeship/server build` succeeds
- [x] `dist/apps/server/src/main.js` exists after build