### PR TITLE
fix: Auto-build server on pnpm dev if dist is missing

### DIFF
--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -5,7 +5,8 @@
  * Finds available ports and starts both frontend and backend servers
  */
 
-const { spawn } = require("child_process");
+const { spawn, execSync } = require("child_process");
+const fs = require("fs");
 const net = require("net");
 const path = require("path");
 
@@ -64,6 +65,14 @@ function startProcess(name, command, args, env, cwd) {
 }
 
 async function main() {
+  // Auto-build server if dist doesn't exist
+  const serverDistMain = path.join(ROOT_DIR, "apps/server/dist/apps/server/src/main.js");
+  if (!fs.existsSync(serverDistMain)) {
+    console.log("Server dist not found, building...\n");
+    execSync("pnpm --filter @claudeship/server build", { cwd: ROOT_DIR, stdio: "inherit" });
+    console.log("");
+  }
+
   console.log("Finding available ports...\n");
 
   // Find available ports (prefer 14000/13000, but use alternatives if busy)


### PR DESCRIPTION
## Summary
- `pnpm dev` fails with `MODULE_NOT_FOUND` if server hasn't been built yet
- Added auto-detection: checks for `dist/apps/server/src/main.js` before starting
- Runs `pnpm --filter @claudeship/server build` automatically if missing

## Test plan
- [x] Fresh checkout 시나리오: dist 없을 때 자동 빌드 후 서버 시작 확인
- [x] 이미 빌드된 상태에서는 빌드 스킵 확인