### PR TITLE
feat: Add clipboard image paste support to chat input

### DIFF
--- a/apps/web/src/components/chat/MessageInput.tsx
+++ b/apps/web/src/components/chat/MessageInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, KeyboardEvent, DragEvent, ChangeEvent } from "react";
+import { useState, useRef, KeyboardEvent, DragEvent, ChangeEvent, ClipboardEvent } from "react";
 import { Send, Clock, Paperclip } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useTranslation } from "@/lib/i18n";
@@ -113,6 +113,28 @@ export function MessageInput({ onSend, projectId, disabled, isStreaming, queueCo
     }
   };
 
+  const handlePaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+
+    const imageFiles: File[] = [];
+    for (const item of Array.from(items)) {
+      if (item.type.startsWith("image/")) {
+        const file = item.getAsFile();
+        if (file) {
+          const ext = file.type.split("/")[1] || "png";
+          const named = new File([file], `clipboard-${Date.now()}.${ext}`, { type: file.type });
+          imageFiles.push(named);
+        }
+      }
+    }
+
+    if (imageFiles.length > 0) {
+      e.preventDefault();
+      handleFilesSelected(imageFiles);
+    }
+  };
+
   const handleInput = () => {
     const textarea = textareaRef.current;
     if (textarea) {
@@ -157,6 +179,7 @@ export function MessageInput({ onSend, projectId, disabled, isStreaming, queueCo
             value={content}
             onChange={(e) => setContent(e.target.value)}
             onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
             onInput={handleInput}
             placeholder={getPlaceholder()}
             disabled={disabled}


### PR DESCRIPTION
## Summary
- 채팅 입력에서 `Ctrl+V` / `Cmd+V`로 클립보드 이미지를 붙여넣기 가능
- 스크린샷, 복사한 이미지가 자동으로 파일 첨부로 추가됨
- 기존 파일 업로드 플로우(검증, 미리보기, 업로드)를 그대로 활용
- 텍스트 붙여넣기는 영향 없음 (이미지가 있을 때만 가로챔)

## Test plan
- [x] 서버 빌드 성공
- [ ] 스크린샷 Ctrl+V → FilePreview에 이미지 표시 확인
- [ ] 이미지 복사 후 Ctrl+V → 첨부 확인
- [ ] 텍스트 Ctrl+V → 기존처럼 텍스트 입력 확인
- [ ] 5개 파일 제한 동작 확인