### PR TITLE
fix: Remove undefined killPromises variable

### DIFF
--- a/apps/server/src/preview/preview.service.ts
+++ b/apps/server/src/preview/preview.service.ts
@@ -721,7 +721,6 @@ export class PreviewService implements OnModuleDestroy {
       // Clean up log resources for each project
       this.cleanupLogResources(projectId);
     }
-    await Promise.all(killPromises);
 
     this.previews.clear();
     this.activeConnections.clear();


### PR DESCRIPTION
## Summary
- Remove `await Promise.all(killPromises)` that referenced an undefined variable
- This was causing TypeScript compilation error on `pnpm dev`

## Test plan
- [x] `pnpm build` success
- [x] `pnpm dev` starts without TS errors
- [x] Preview start/stop works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)