### PR TITLE
feat: Implement Phase 002 - Claude Code modes & dev productivity features

### DIFF
--- a/apps/server/src/agent/agent.controller.ts
+++ b/apps/server/src/agent/agent.controller.ts
@@ -1,0 +1,61 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+} from "@nestjs/common";
+import { AgentService, type CustomAgent } from "./agent.service";
+
+@Controller("projects/:projectId/agents")
+export class AgentController {
+  constructor(private readonly agentService: AgentService) {}
+
+  @Get()
+  listAgents(@Param("projectId") projectId: string) {
+    return this.agentService.listAgents(projectId);
+  }
+
+  @Get(":name")
+  getAgent(
+    @Param("projectId") projectId: string,
+    @Param("name") name: string,
+  ) {
+    return this.agentService.getAgent(projectId, name);
+  }
+
+  @Post()
+  createAgent(
+    @Param("projectId") projectId: string,
+    @Body() body: CustomAgent,
+  ) {
+    return this.agentService.createAgent(projectId, body);
+  }
+
+  @Put(":name")
+  updateAgent(
+    @Param("projectId") projectId: string,
+    @Param("name") name: string,
+    @Body() body: CustomAgent,
+  ) {
+    return this.agentService.updateAgent(projectId, name, body);
+  }
+
+  @Delete(":name")
+  deleteAgent(
+    @Param("projectId") projectId: string,
+    @Param("name") name: string,
+  ) {
+    return this.agentService.deleteAgent(projectId, name);
+  }
+
+  @Post(":name/run")
+  runAgent(
+    @Param("projectId") projectId: string,
+    @Param("name") name: string,
+  ) {
+    return this.agentService.runAgent(projectId, name);
+  }
+}

--- a/apps/server/src/agent/agent.module.ts
+++ b/apps/server/src/agent/agent.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { AgentController } from "./agent.controller";
+import { AgentService } from "./agent.service";
+import { ProjectModule } from "../project/project.module";
+import { ChatModule } from "../chat/chat.module";
+
+@Module({
+  imports: [ProjectModule, ChatModule],
+  controllers: [AgentController],
+  providers: [AgentService],
+  exports: [AgentService],
+})
+export class AgentModule {}

--- a/apps/server/src/agent/agent.service.ts
+++ b/apps/server/src/agent/agent.service.ts
@@ -1,0 +1,237 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  BadRequestException,
+} from "@nestjs/common";
+import { ProjectService } from "../project/project.service";
+import { ChatService } from "../chat/chat.service";
+import * as path from "path";
+import * as fs from "fs/promises";
+import { existsSync } from "fs";
+
+export interface CustomAgent {
+  name: string;
+  description: string;
+  tools: string[];
+  prompt: string;
+}
+
+/**
+ * Simple YAML parser for Claude Code agent files.
+ * Handles flat key-value pairs, arrays, and multiline strings (block scalar |).
+ */
+function parseAgentYaml(content: string): CustomAgent {
+  const result: Record<string, string | string[]> = {};
+  const lines = content.split("\n");
+  let currentKey = "";
+  let multilineValue = "";
+  let inMultiline = false;
+  let inArray = false;
+  let arrayValues: string[] = [];
+
+  for (const line of lines) {
+    if (inMultiline) {
+      if (line.startsWith("  ") || line.trim() === "") {
+        multilineValue += (multilineValue ? "\n" : "") + line.replace(/^ {2}/, "");
+        continue;
+      } else {
+        result[currentKey] = multilineValue;
+        inMultiline = false;
+        multilineValue = "";
+      }
+    }
+
+    if (inArray) {
+      if (line.match(/^\s+-\s+/)) {
+        arrayValues.push(line.replace(/^\s+-\s+/, "").trim());
+        continue;
+      } else {
+        result[currentKey] = arrayValues;
+        inArray = false;
+        arrayValues = [];
+      }
+    }
+
+    const match = line.match(/^(\w+):\s*(.*)/);
+    if (match) {
+      currentKey = match[1];
+      const value = match[2].trim();
+
+      if (value === "|") {
+        inMultiline = true;
+        multilineValue = "";
+      } else if (value === "") {
+        // Could be array on next line
+        inArray = true;
+        arrayValues = [];
+      } else {
+        result[currentKey] = value;
+      }
+    }
+  }
+
+  if (inMultiline) {
+    result[currentKey] = multilineValue;
+  }
+  if (inArray) {
+    result[currentKey] = arrayValues;
+  }
+
+  return {
+    name: (result.name as string) || "",
+    description: (result.description as string) || "",
+    tools: Array.isArray(result.tools) ? result.tools : [],
+    prompt: (result.prompt as string) || "",
+  };
+}
+
+function formatAgentYaml(agent: CustomAgent): string {
+  let content = `name: ${agent.name}\n`;
+  content += `description: ${agent.description}\n`;
+  content += `tools:\n`;
+  for (const tool of agent.tools) {
+    content += `  - ${tool}\n`;
+  }
+  content += `prompt: |\n`;
+  for (const line of agent.prompt.split("\n")) {
+    content += `  ${line}\n`;
+  }
+  return content;
+}
+
+@Injectable()
+export class AgentService {
+  private readonly logger = new Logger(AgentService.name);
+
+  constructor(
+    private projectService: ProjectService,
+    private chatService: ChatService,
+  ) {}
+
+  private async getAgentsDir(projectId: string): Promise<string> {
+    const projectPath = await this.projectService.getProjectPath(projectId);
+    return path.join(projectPath, ".claude", "agents");
+  }
+
+  async listAgents(projectId: string): Promise<CustomAgent[]> {
+    const agentsDir = await this.getAgentsDir(projectId);
+
+    if (!existsSync(agentsDir)) {
+      return [];
+    }
+
+    const files = await fs.readdir(agentsDir);
+    const agents: CustomAgent[] = [];
+
+    for (const file of files) {
+      if (!file.endsWith(".yml") && !file.endsWith(".yaml")) continue;
+
+      try {
+        const content = await fs.readFile(
+          path.join(agentsDir, file),
+          "utf-8",
+        );
+        const parsed = parseAgentYaml(content);
+        if (parsed.name) {
+          agents.push(parsed);
+        }
+      } catch (error) {
+        this.logger.warn(`Failed to parse agent file ${file}: ${error}`);
+      }
+    }
+
+    return agents;
+  }
+
+  async getAgent(projectId: string, name: string): Promise<CustomAgent> {
+    const agentsDir = await this.getAgentsDir(projectId);
+    const filePath = path.join(agentsDir, `${this.sanitizeName(name)}.yml`);
+
+    if (!existsSync(filePath)) {
+      throw new NotFoundException(`Agent not found: ${name}`);
+    }
+
+    const content = await fs.readFile(filePath, "utf-8");
+    return parseAgentYaml(content);
+  }
+
+  async createAgent(
+    projectId: string,
+    agent: CustomAgent,
+  ): Promise<CustomAgent> {
+    const agentsDir = await this.getAgentsDir(projectId);
+
+    await fs.mkdir(agentsDir, { recursive: true });
+
+    const fileName = `${this.sanitizeName(agent.name)}.yml`;
+    const filePath = path.join(agentsDir, fileName);
+
+    if (existsSync(filePath)) {
+      throw new BadRequestException(`Agent already exists: ${agent.name}`);
+    }
+
+    await fs.writeFile(filePath, formatAgentYaml(agent), "utf-8");
+    return agent;
+  }
+
+  async updateAgent(
+    projectId: string,
+    name: string,
+    agent: CustomAgent,
+  ): Promise<CustomAgent> {
+    const agentsDir = await this.getAgentsDir(projectId);
+    const filePath = path.join(agentsDir, `${this.sanitizeName(name)}.yml`);
+
+    if (!existsSync(filePath)) {
+      throw new NotFoundException(`Agent not found: ${name}`);
+    }
+
+    await fs.writeFile(filePath, formatAgentYaml(agent), "utf-8");
+
+    if (name !== agent.name) {
+      const newFilePath = path.join(
+        agentsDir,
+        `${this.sanitizeName(agent.name)}.yml`,
+      );
+      await fs.rename(filePath, newFilePath);
+    }
+
+    return agent;
+  }
+
+  async deleteAgent(projectId: string, name: string): Promise<void> {
+    const agentsDir = await this.getAgentsDir(projectId);
+    const filePath = path.join(agentsDir, `${this.sanitizeName(name)}.yml`);
+
+    if (!existsSync(filePath)) {
+      throw new NotFoundException(`Agent not found: ${name}`);
+    }
+
+    await fs.unlink(filePath);
+  }
+
+  async runAgent(
+    projectId: string,
+    name: string,
+  ): Promise<{ message: string }> {
+    const agent = await this.getAgent(projectId, name);
+
+    const prompt = `[Custom Agent: ${agent.name}]\n\n${agent.prompt}`;
+    this.chatService.sendMessage(projectId, prompt, "build").subscribe({
+      error: (err) => {
+        this.logger.error(`Agent run failed: ${err.message}`);
+      },
+    });
+
+    return { message: `Agent "${agent.name}" started` };
+  }
+
+  private sanitizeName(name: string): string {
+    return name
+      .toLowerCase()
+      .replace(/[^a-z0-9-_]/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "");
+  }
+}

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -15,6 +15,8 @@ import { CheckpointModule } from "./checkpoint/checkpoint.module";
 import { ProjectContextModule } from "./project-context/project-context.module";
 import { EnvModule } from "./env/env.module";
 import { ArchitectModule } from "./architect/architect.module";
+import { AgentModule } from "./agent/agent.module";
+import { TerminalModule } from "./terminal/terminal.module";
 
 @Module({
   imports: [
@@ -34,6 +36,8 @@ import { ArchitectModule } from "./architect/architect.module";
     ProjectContextModule,
     EnvModule,
     ArchitectModule,
+    AgentModule,
+    TerminalModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/server/src/architect/prompts/review-prompt.ts
+++ b/apps/server/src/architect/prompts/review-prompt.ts
@@ -5,7 +5,7 @@
  */
 
 export function buildReviewPrompt(projectPath: string): string {
-  return `You are a senior code reviewer. Analyze the recent code changes in the project at "${projectPath}".
+  return `You are a senior code reviewer and security auditor. Analyze the recent code changes in the project at "${projectPath}".
 
 ## Review Categories
 
@@ -15,12 +15,38 @@ export function buildReviewPrompt(projectPath: string): string {
 4. **Performance** - N+1 queries, memory leaks, unnecessary computation, bundle size
 5. **Quality** - Naming, readability, duplication, missing error handling
 
+## Security Scan (OWASP Top 10)
+
+Pay special attention to these security concerns:
+
+| OWASP Item | What to Check |
+|------------|---------------|
+| A01: Broken Access Control | Missing authentication/authorization checks, direct object references |
+| A02: Cryptographic Failures | Hardcoded secrets, API keys, passwords in source code |
+| A03: Injection | SQL injection, command injection, XSS vulnerabilities |
+| A07: Auth Failures | Weak password policies, missing rate limiting |
+| A09: Logging Failures | Sensitive data in logs (tokens, passwords, PII) |
+
+## Code Structure Analysis
+
+Also analyze these structural quality metrics:
+
+| Metric | Threshold |
+|--------|-----------|
+| File size | Warn if >300 lines |
+| Folder depth | Warn if >5 levels |
+| God component | Single component with too much logic (>200 lines of JSX) |
+| Code duplication | Repeated patterns across files |
+| Naming consistency | Mixed camelCase/PascalCase/snake_case |
+| Unused code | Imported but unused modules/variables |
+
 ## Instructions
 
 1. Read the recently modified files using the Read tool
-2. Analyze the code for issues across all categories
-3. Identify strengths and positive patterns
-4. Provide actionable recommendations
+2. Analyze the code for issues across all categories, including OWASP security checks
+3. Check code structure metrics (file size, complexity, duplication)
+4. Identify strengths and positive patterns
+5. Provide actionable recommendations
 
 ## Output Format
 

--- a/apps/server/src/chat/claude-cli.service.ts
+++ b/apps/server/src/chat/claude-cli.service.ts
@@ -37,6 +37,9 @@ export interface ClaudeStreamEvent {
 // Ask mode: read-only tools only
 const ASK_MODE_TOOLS = ["Read", "Glob", "Grep", "LSP", "WebFetch", "WebSearch"];
 
+// Plan mode: read-only tools + planning tools (Task, TodoWrite for plan output)
+const PLAN_MODE_TOOLS = ["Read", "Glob", "Grep", "LSP", "WebFetch", "WebSearch", "Task", "TodoWrite"];
+
 // All tools to allow when running as root (--dangerously-skip-permissions is rejected by root)
 const ROOT_ALLOWED_TOOLS = ["Bash", "Write", "Edit", "NotebookEdit", "Read", "Glob", "Grep", "WebFetch", "WebSearch", "TodoWrite", "Task"];
 
@@ -78,7 +81,8 @@ export class ClaudeCliService {
 
       // Build CLI command with optional resume flag and mode-specific tools
       const resumeFlag = resumeSessionId ? `--resume "${resumeSessionId}"` : "";
-      const toolsFlag = mode === "ask" ? `--tools "${ASK_MODE_TOOLS.join(",")}"` : "";
+      const modeTools = mode === "ask" ? ASK_MODE_TOOLS : mode === "plan" ? PLAN_MODE_TOOLS : null;
+      const toolsFlag = modeTools ? `--tools "${modeTools.join(",")}"` : "";
       // Root cannot use --dangerously-skip-permissions; use acceptEdits + allowedTools instead
       const isRoot = process.getuid?.() === 0;
       const permissionsFlag = isRoot
@@ -92,6 +96,8 @@ export class ClaudeCliService {
       }
       if (mode === "ask") {
         this.logger.log(`Ask mode: restricting tools to ${ASK_MODE_TOOLS.join(", ")}`);
+      } else if (mode === "plan") {
+        this.logger.log(`Plan mode: restricting tools to ${PLAN_MODE_TOOLS.join(", ")}`);
       }
 
       this.logger.log(`Using temp file: ${tempFile}`);

--- a/apps/server/src/chat/dto/send-message.dto.ts
+++ b/apps/server/src/chat/dto/send-message.dto.ts
@@ -1,4 +1,4 @@
-export type ChatMode = "ask" | "build";
+export type ChatMode = "ask" | "build" | "plan";
 
 export class SendMessageDto {
   content: string;

--- a/apps/server/src/file/file.controller.ts
+++ b/apps/server/src/file/file.controller.ts
@@ -1,9 +1,11 @@
 import {
   Controller,
   Get,
+  Put,
   Post,
   Param,
   Query,
+  Body,
   UseInterceptors,
   UploadedFiles,
   BadRequestException,
@@ -29,6 +31,14 @@ export class FileController {
     @Query("path") filePath: string
   ): Promise<{ content: string; language: string }> {
     return this.fileService.getFileContent(projectId, filePath);
+  }
+
+  @Put("content")
+  async saveFileContent(
+    @Param("projectId") projectId: string,
+    @Body() body: { path: string; content: string },
+  ): Promise<{ success: boolean }> {
+    return this.fileService.saveFileContent(projectId, body.path, body.content);
   }
 
   @Post("upload")

--- a/apps/server/src/file/file.service.ts
+++ b/apps/server/src/file/file.service.ts
@@ -136,6 +136,35 @@ export class FileService {
     }
   }
 
+  async saveFileContent(
+    projectId: string,
+    filePath: string,
+    content: string,
+  ): Promise<{ success: boolean }> {
+    const projectPath = await this.projectService.getProjectPath(projectId);
+    const fullPath = path.join(projectPath, filePath);
+
+    // Security: Prevent directory traversal
+    const resolvedPath = path.resolve(fullPath);
+    const resolvedProjectPath = path.resolve(projectPath);
+    if (!resolvedPath.startsWith(resolvedProjectPath)) {
+      throw new BadRequestException("Invalid file path");
+    }
+
+    // Prevent editing binary files
+    const binaryExts = [".png", ".jpg", ".jpeg", ".gif", ".ico", ".woff", ".woff2", ".ttf", ".eot", ".pdf", ".zip"];
+    if (binaryExts.includes(path.extname(filePath).toLowerCase())) {
+      throw new BadRequestException("Cannot edit binary files");
+    }
+
+    try {
+      await fs.writeFile(fullPath, content, "utf-8");
+      return { success: true };
+    } catch {
+      throw new BadRequestException("Failed to save file");
+    }
+  }
+
   private getLanguageFromExtension(ext: string): string {
     const languageMap: Record<string, string> = {
       ts: "typescript",

--- a/apps/server/src/terminal/terminal.controller.ts
+++ b/apps/server/src/terminal/terminal.controller.ts
@@ -1,0 +1,45 @@
+import { Controller, Post, Delete, Param, Body, Sse, Res } from "@nestjs/common";
+import { TerminalService } from "./terminal.service";
+import { Observable, map } from "rxjs";
+import type { Response } from "express";
+
+@Controller("projects/:projectId/terminal")
+export class TerminalController {
+  constructor(private readonly terminalService: TerminalService) {}
+
+  @Post("execute")
+  @Sse()
+  async execute(
+    @Param("projectId") projectId: string,
+    @Body() body: { command: string },
+    @Res() res: Response,
+  ): Promise<void> {
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache");
+    res.setHeader("Connection", "keep-alive");
+
+    const stream = await this.terminalService.executeCommand(
+      projectId,
+      body.command,
+    );
+
+    stream.subscribe({
+      next: (event) => {
+        res.write(`data: ${JSON.stringify(event)}\n\n`);
+      },
+      complete: () => {
+        res.write("data: [DONE]\n\n");
+        res.end();
+      },
+      error: () => {
+        res.end();
+      },
+    });
+  }
+
+  @Delete("kill")
+  kill(@Param("projectId") projectId: string) {
+    this.terminalService.killProcess(projectId);
+    return { message: "Process terminated" };
+  }
+}

--- a/apps/server/src/terminal/terminal.module.ts
+++ b/apps/server/src/terminal/terminal.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { TerminalController } from "./terminal.controller";
+import { TerminalService } from "./terminal.service";
+import { ProjectModule } from "../project/project.module";
+
+@Module({
+  imports: [ProjectModule],
+  controllers: [TerminalController],
+  providers: [TerminalService],
+  exports: [TerminalService],
+})
+export class TerminalModule {}

--- a/apps/server/src/terminal/terminal.service.ts
+++ b/apps/server/src/terminal/terminal.service.ts
@@ -1,0 +1,68 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { ProjectService } from "../project/project.service";
+import { spawn, type ChildProcess } from "child_process";
+import { Observable, Subject } from "rxjs";
+
+export interface TerminalOutput {
+  type: "stdout" | "stderr" | "exit";
+  data?: string;
+  exitCode?: number;
+}
+
+@Injectable()
+export class TerminalService {
+  private readonly logger = new Logger(TerminalService.name);
+  private processes: Map<string, ChildProcess> = new Map();
+
+  constructor(private projectService: ProjectService) {}
+
+  async executeCommand(
+    projectId: string,
+    command: string,
+  ): Promise<Observable<TerminalOutput>> {
+    const projectPath = await this.projectService.getProjectPath(projectId);
+
+    const subject = new Subject<TerminalOutput>();
+
+    const proc = spawn("sh", ["-c", command], {
+      cwd: projectPath,
+      env: { ...process.env, TERM: "xterm-256color" },
+      shell: false,
+    });
+
+    const processId = `${projectId}-${Date.now()}`;
+    this.processes.set(processId, proc);
+
+    proc.stdout?.on("data", (data: Buffer) => {
+      subject.next({ type: "stdout", data: data.toString() });
+    });
+
+    proc.stderr?.on("data", (data: Buffer) => {
+      subject.next({ type: "stderr", data: data.toString() });
+    });
+
+    proc.on("close", (code) => {
+      subject.next({ type: "exit", exitCode: code ?? 0 });
+      subject.complete();
+      this.processes.delete(processId);
+    });
+
+    proc.on("error", (err) => {
+      this.logger.error(`Terminal process error: ${err.message}`);
+      subject.next({ type: "stderr", data: err.message });
+      subject.complete();
+      this.processes.delete(processId);
+    });
+
+    return subject.asObservable();
+  }
+
+  killProcess(projectId: string): void {
+    for (const [id, proc] of this.processes) {
+      if (id.startsWith(projectId)) {
+        proc.kill("SIGTERM");
+        this.processes.delete(id);
+      }
+    }
+  }
+}

--- a/apps/web/src/components/agent/AgentPanel.tsx
+++ b/apps/web/src/components/agent/AgentPanel.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import {
+  Bot,
+  Plus,
+  Play,
+  Pencil,
+  Trash2,
+  Loader2,
+  X,
+  Save,
+} from "lucide-react";
+
+interface CustomAgent {
+  name: string;
+  description: string;
+  tools: string[];
+  prompt: string;
+}
+
+interface AgentPanelProps {
+  projectId: string;
+}
+
+const AVAILABLE_TOOLS = [
+  "Read",
+  "Glob",
+  "Grep",
+  "Bash",
+  "Edit",
+  "Write",
+  "WebFetch",
+  "WebSearch",
+  "Task",
+];
+
+function AgentForm({
+  agent,
+  onSave,
+  onCancel,
+}: {
+  agent?: CustomAgent;
+  onSave: (agent: CustomAgent) => void;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState(agent?.name || "");
+  const [description, setDescription] = useState(agent?.description || "");
+  const [tools, setTools] = useState<string[]>(agent?.tools || ["Read", "Glob", "Grep"]);
+  const [prompt, setPrompt] = useState(agent?.prompt || "");
+
+  const toggleTool = (tool: string) => {
+    setTools((prev) =>
+      prev.includes(tool) ? prev.filter((t) => t !== tool) : [...prev, tool],
+    );
+  };
+
+  const handleSubmit = () => {
+    if (!name.trim() || !prompt.trim()) return;
+    onSave({ name: name.trim(), description: description.trim(), tools, prompt: prompt.trim() });
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="font-medium text-sm">
+          {agent ? "Edit Agent" : "New Agent"}
+        </h3>
+        <Button variant="ghost" size="sm" onClick={onCancel} className="h-7 w-7 p-0">
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <label className="text-xs font-medium text-muted-foreground">Name</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g., Code Reviewer"
+            className="w-full mt-1 px-3 py-1.5 text-sm border rounded-md bg-background"
+          />
+        </div>
+
+        <div>
+          <label className="text-xs font-medium text-muted-foreground">Description</label>
+          <input
+            type="text"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="e.g., Reviews code for best practices"
+            className="w-full mt-1 px-3 py-1.5 text-sm border rounded-md bg-background"
+          />
+        </div>
+
+        <div>
+          <label className="text-xs font-medium text-muted-foreground">Tools</label>
+          <div className="flex flex-wrap gap-1.5 mt-1">
+            {AVAILABLE_TOOLS.map((tool) => (
+              <button
+                key={tool}
+                onClick={() => toggleTool(tool)}
+                className={`px-2 py-0.5 rounded text-xs font-medium transition-colors ${
+                  tools.includes(tool)
+                    ? "bg-violet-100 text-violet-700 dark:bg-violet-900 dark:text-violet-300"
+                    : "bg-muted text-muted-foreground hover:bg-muted/80"
+                }`}
+              >
+                {tool}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="text-xs font-medium text-muted-foreground">Prompt</label>
+          <textarea
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            placeholder="You are a code reviewer. Analyze the codebase and provide feedback."
+            rows={6}
+            className="w-full mt-1 px-3 py-1.5 text-sm border rounded-md bg-background resize-y font-mono"
+          />
+        </div>
+
+        <Button
+          size="sm"
+          onClick={handleSubmit}
+          disabled={!name.trim() || !prompt.trim()}
+          className="w-full"
+        >
+          <Save className="h-4 w-4 mr-1" />
+          {agent ? "Update" : "Create"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function AgentPanel({ projectId }: AgentPanelProps) {
+  const [agents, setAgents] = useState<CustomAgent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [runningAgent, setRunningAgent] = useState<string | null>(null);
+  const [editingAgent, setEditingAgent] = useState<CustomAgent | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+
+  const fetchAgents = async () => {
+    try {
+      setLoading(true);
+      const data = await api.get<CustomAgent[]>(
+        `/projects/${projectId}/agents`,
+      );
+      setAgents(data);
+    } catch {
+      setAgents([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAgents();
+  }, [projectId]);
+
+  const handleRun = async (name: string) => {
+    setRunningAgent(name);
+    try {
+      await api.post(`/projects/${projectId}/agents/${encodeURIComponent(name)}/run`);
+    } finally {
+      setTimeout(() => setRunningAgent(null), 2000);
+    }
+  };
+
+  const handleDelete = async (name: string) => {
+    await api.delete(`/projects/${projectId}/agents/${encodeURIComponent(name)}`);
+    fetchAgents();
+  };
+
+  const handleCreate = async (agent: CustomAgent) => {
+    await api.post(`/projects/${projectId}/agents`, agent);
+    setShowCreate(false);
+    fetchAgents();
+  };
+
+  const handleUpdate = async (agent: CustomAgent) => {
+    if (!editingAgent) return;
+    await api.put(
+      `/projects/${projectId}/agents/${encodeURIComponent(editingAgent.name)}`,
+      agent,
+    );
+    setEditingAgent(null);
+    fetchAgents();
+  };
+
+  if (showCreate) {
+    return (
+      <AgentForm
+        onSave={handleCreate}
+        onCancel={() => setShowCreate(false)}
+      />
+    );
+  }
+
+  if (editingAgent) {
+    return (
+      <AgentForm
+        agent={editingAgent}
+        onSave={handleUpdate}
+        onCancel={() => setEditingAgent(null)}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="p-3 border-b flex items-center justify-between">
+        <h3 className="font-medium text-sm">Custom Agents</h3>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setShowCreate(true)}
+          className="h-7 text-xs"
+        >
+          <Plus className="h-3 w-3 mr-1" />
+          New
+        </Button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {loading ? (
+          <div className="flex items-center justify-center h-32">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : agents.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-8">
+            <Bot className="h-12 w-12 mb-4 opacity-50" />
+            <p className="text-sm text-center mb-2">No custom agents yet.</p>
+            <p className="text-xs text-center mb-4">
+              Create agents to automate repetitive tasks.
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowCreate(true)}
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              Create Agent
+            </Button>
+          </div>
+        ) : (
+          <div className="p-3 space-y-2">
+            {agents.map((agent) => (
+              <div
+                key={agent.name}
+                className="border rounded-lg p-3 space-y-2 bg-background"
+              >
+                <div className="flex items-start justify-between">
+                  <div className="flex items-center gap-2">
+                    <Bot className="h-4 w-4 text-violet-600" />
+                    <span className="font-medium text-sm">{agent.name}</span>
+                  </div>
+                </div>
+
+                {agent.description && (
+                  <p className="text-xs text-muted-foreground">
+                    {agent.description}
+                  </p>
+                )}
+
+                <div className="flex flex-wrap gap-1">
+                  {agent.tools.map((tool) => (
+                    <span
+                      key={tool}
+                      className="px-1.5 py-0.5 rounded text-xs bg-muted text-muted-foreground"
+                    >
+                      {tool}
+                    </span>
+                  ))}
+                </div>
+
+                <div className="flex items-center gap-1.5 pt-1">
+                  <Button
+                    size="sm"
+                    variant="default"
+                    onClick={() => handleRun(agent.name)}
+                    disabled={runningAgent === agent.name}
+                    className="h-6 text-xs"
+                  >
+                    {runningAgent === agent.name ? (
+                      <Loader2 className="h-3 w-3 animate-spin mr-1" />
+                    ) : (
+                      <Play className="h-3 w-3 mr-1" />
+                    )}
+                    Run
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setEditingAgent(agent)}
+                    className="h-6 text-xs"
+                  >
+                    <Pencil className="h-3 w-3 mr-1" />
+                    Edit
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => handleDelete(agent.name)}
+                    className="h-6 text-xs text-red-600 hover:text-red-700"
+                  >
+                    <Trash2 className="h-3 w-3" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/architect/ArchitectPanel.tsx
+++ b/apps/web/src/components/architect/ArchitectPanel.tsx
@@ -68,6 +68,7 @@ export function ArchitectPanel({ projectId }: ArchitectPanelProps) {
   } = useArchitectStore();
 
   const [selectedReviewId, setSelectedReviewId] = useState<string | null>(null);
+  const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
 
   useEffect(() => {
     fetchReviews(projectId);
@@ -94,15 +95,24 @@ export function ArchitectPanel({ projectId }: ArchitectPanelProps) {
 
   const selectedReview = activeReview?.id === selectedReviewId ? activeReview : null;
 
+  const filteredIssues = selectedReview?.issues
+    ? categoryFilter
+      ? selectedReview.issues.filter((i) => i.category === categoryFilter)
+      : selectedReview.issues
+    : [];
+
   const groupedIssues: Record<string, ReviewIssue[]> = {};
-  if (selectedReview?.issues) {
-    for (const issue of selectedReview.issues) {
-      if (!groupedIssues[issue.severity]) {
-        groupedIssues[issue.severity] = [];
-      }
-      groupedIssues[issue.severity].push(issue);
+  for (const issue of filteredIssues) {
+    if (!groupedIssues[issue.severity]) {
+      groupedIssues[issue.severity] = [];
     }
+    groupedIssues[issue.severity].push(issue);
   }
+
+  // Unique categories from all issues for filter buttons
+  const availableCategories = selectedReview?.issues
+    ? [...new Set(selectedReview.issues.map((i) => i.category))]
+    : [];
 
   const severityOrder = ["critical", "high", "medium", "low"];
 
@@ -233,8 +243,41 @@ export function ArchitectPanel({ projectId }: ArchitectPanelProps) {
               <div className="space-y-3">
                 <h4 className="font-medium text-sm flex items-center gap-2">
                   <AlertTriangle className="h-4 w-4" />
-                  Issues ({selectedReview.issues.length})
+                  Issues ({filteredIssues.length}
+                  {categoryFilter ? ` / ${selectedReview.issues.length}` : ""})
                 </h4>
+
+                {/* Category filter */}
+                {availableCategories.length > 1 && (
+                  <div className="flex flex-wrap gap-1">
+                    <button
+                      onClick={() => setCategoryFilter(null)}
+                      className={cn(
+                        "px-2 py-0.5 rounded text-xs font-medium transition-colors",
+                        !categoryFilter
+                          ? "bg-foreground text-background"
+                          : "bg-muted text-muted-foreground hover:bg-muted/80",
+                      )}
+                    >
+                      All
+                    </button>
+                    {availableCategories.map((cat) => (
+                      <button
+                        key={cat}
+                        onClick={() => setCategoryFilter(categoryFilter === cat ? null : cat)}
+                        className={cn(
+                          "px-2 py-0.5 rounded text-xs font-medium transition-colors capitalize",
+                          categoryFilter === cat
+                            ? "bg-foreground text-background"
+                            : "bg-muted text-muted-foreground hover:bg-muted/80",
+                        )}
+                      >
+                        {cat}
+                      </button>
+                    ))}
+                  </div>
+                )}
+
                 {severityOrder.map((severity) =>
                   groupedIssues[severity]?.length ? (
                     <div key={severity} className="space-y-2">
@@ -242,7 +285,7 @@ export function ArchitectPanel({ projectId }: ArchitectPanelProps) {
                         {severity} ({groupedIssues[severity].length})
                       </h5>
                       {groupedIssues[severity].map((issue, idx) => (
-                        <IssueCard key={`${severity}-${idx}`} issue={issue} />
+                        <IssueCard key={`${severity}-${idx}`} issue={issue} projectId={projectId} />
                       ))}
                     </div>
                   ) : null,

--- a/apps/web/src/components/architect/IssueCard.tsx
+++ b/apps/web/src/components/architect/IssueCard.tsx
@@ -2,6 +2,8 @@
 
 import { cn } from "@/lib/utils";
 import type { ReviewIssue } from "@claudeship/shared";
+import { useChatStore } from "@/stores/useChatStore";
+import { Button } from "@/components/ui/button";
 import {
   ShieldAlert,
   Bug,
@@ -9,10 +11,12 @@ import {
   Gauge,
   Code2,
   FileCode,
+  Wand2,
 } from "lucide-react";
 
 interface IssueCardProps {
   issue: ReviewIssue;
+  projectId?: string;
 }
 
 const severityConfig: Record<
@@ -33,8 +37,21 @@ const categoryIcons: Record<string, React.ReactNode> = {
   quality: <Code2 className="h-3.5 w-3.5" />,
 };
 
-export function IssueCard({ issue }: IssueCardProps) {
+export function IssueCard({ issue, projectId }: IssueCardProps) {
   const severity = severityConfig[issue.severity] || severityConfig.low;
+  const { sendMessage, setMode } = useChatStore();
+
+  const handleFix = () => {
+    if (!projectId) return;
+
+    const location = issue.file
+      ? `\nFile: ${issue.file}${issue.line ? `:${issue.line}` : ""}`
+      : "";
+    const prompt = `Fix this ${issue.category} issue:\n[${issue.severity.toUpperCase()}] ${issue.title}\n${issue.description}${location}${issue.suggestion ? `\n\nSuggestion: ${issue.suggestion}` : ""}`;
+
+    setMode("build");
+    sendMessage(projectId, prompt);
+  };
 
   return (
     <div className="border rounded-lg p-3 space-y-2 bg-background">
@@ -76,6 +93,19 @@ export function IssueCard({ issue }: IssueCardProps) {
         <div className="bg-muted/50 rounded p-2 text-xs">
           <span className="font-medium">Suggestion: </span>
           {issue.suggestion}
+        </div>
+      )}
+
+      {issue.autoFixable && projectId && (
+        <div className="pt-1">
+          <Button
+            size="sm"
+            onClick={handleFix}
+            className="h-6 text-xs bg-violet-600 hover:bg-violet-700 text-white"
+          >
+            <Wand2 className="h-3 w-3 mr-1" />
+            Fix
+          </Button>
         </div>
       )}
     </div>

--- a/apps/web/src/components/chat/ChatPanel.tsx
+++ b/apps/web/src/components/chat/ChatPanel.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { RotateCcw, MessageSquarePlus } from "lucide-react";
 import { useTranslation } from "@/lib/i18n";
 import { api } from "@/lib/api";
+import { ClaudeStatusBar } from "./ClaudeStatusBar";
 
 interface ChatPanelProps {
   projectId: string;
@@ -72,6 +73,9 @@ export function ChatPanel({ projectId }: ChatPanelProps) {
           <span className="hidden sm:inline">{t("chat.newConversation")}</span>
         </Button>
       </div>
+
+      {/* Claude Status Bar */}
+      <ClaudeStatusBar />
 
       <MessageList
         messages={messages}

--- a/apps/web/src/components/chat/ClaudeStatusBar.tsx
+++ b/apps/web/src/components/chat/ClaudeStatusBar.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useChatStore } from "@/stores/useChatStore";
+import {
+  Activity,
+  Clock,
+  DollarSign,
+  Wrench,
+  Map,
+  MessageCircleQuestion,
+  Hammer,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const modeConfig = {
+  ask: { icon: MessageCircleQuestion, label: "Ask", color: "text-blue-500", bg: "bg-blue-500/10" },
+  plan: { icon: Map, label: "Plan", color: "text-violet-500", bg: "bg-violet-500/10" },
+  build: { icon: Hammer, label: "Build", color: "text-green-500", bg: "bg-green-500/10" },
+} as const;
+
+function formatDuration(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}m ${remainingSeconds}s`;
+}
+
+function formatCost(cost: number): string {
+  if (cost < 0.01) return `$${cost.toFixed(4)}`;
+  return `$${cost.toFixed(2)}`;
+}
+
+export function ClaudeStatusBar() {
+  const { mode, isStreaming, streamingBlocks, streamStartedAt, lastCost, totalCost } = useChatStore();
+  const [elapsed, setElapsed] = useState(0);
+
+  const toolCount = streamingBlocks.filter((b) => b.type === "tool_use").length;
+  const runningTools = streamingBlocks.filter((b) => b.type === "tool_use" && b.status === "running").length;
+  const config = modeConfig[mode];
+  const ModeIcon = config.icon;
+
+  useEffect(() => {
+    if (!isStreaming || !streamStartedAt) {
+      setElapsed(0);
+      return;
+    }
+
+    setElapsed(Date.now() - streamStartedAt);
+    const interval = setInterval(() => {
+      setElapsed(Date.now() - streamStartedAt);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [isStreaming, streamStartedAt]);
+
+  return (
+    <div className="flex items-center gap-3 px-4 py-1.5 text-xs border-b bg-muted/30">
+      {/* Mode Indicator */}
+      <div className={cn("flex items-center gap-1 px-1.5 py-0.5 rounded", config.bg)}>
+        <ModeIcon className={cn("h-3 w-3", config.color)} />
+        <span className={cn("font-medium", config.color)}>{config.label}</span>
+      </div>
+
+      {/* Streaming Status */}
+      {isStreaming && (
+        <div className="flex items-center gap-1 text-amber-500">
+          <Activity className="h-3 w-3 animate-pulse" />
+          <span>Active</span>
+        </div>
+      )}
+
+      {/* Duration */}
+      {isStreaming && elapsed > 0 && (
+        <div className="flex items-center gap-1 text-muted-foreground">
+          <Clock className="h-3 w-3" />
+          <span className="tabular-nums">{formatDuration(elapsed)}</span>
+        </div>
+      )}
+
+      {/* Tool Count */}
+      {toolCount > 0 && (
+        <div className="flex items-center gap-1 text-muted-foreground">
+          <Wrench className="h-3 w-3" />
+          <span className="tabular-nums">
+            {toolCount}{runningTools > 0 ? ` (${runningTools} running)` : ""}
+          </span>
+        </div>
+      )}
+
+      {/* Cost */}
+      {(lastCost || totalCost > 0) && (
+        <div className="flex items-center gap-1 text-muted-foreground ml-auto">
+          <DollarSign className="h-3 w-3" />
+          <span className="tabular-nums">
+            {lastCost ? formatCost(lastCost) : ""}
+            {totalCost > 0 && lastCost !== totalCost && (
+              <span className="text-muted-foreground/60"> / {formatCost(totalCost)}</span>
+            )}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/MessageInput.tsx
+++ b/apps/web/src/components/chat/MessageInput.tsx
@@ -43,7 +43,9 @@ export function MessageInput({ onSend, projectId, disabled, isStreaming, queueCo
 
   const getPlaceholder = () => {
     if (isStreaming) return t("chat.queuePlaceholder");
-    return mode === "ask" ? t("chat.askPlaceholder") : t("chat.placeholder");
+    if (mode === "ask") return t("chat.askPlaceholder");
+    if (mode === "plan") return t("chat.planPlaceholder");
+    return t("chat.placeholder");
   };
 
   const handleFilesSelected = (files: File[]) => {

--- a/apps/web/src/components/chat/ModeToggle.tsx
+++ b/apps/web/src/components/chat/ModeToggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MessageCircleQuestion, Hammer } from "lucide-react";
+import { MessageCircleQuestion, Hammer, Map } from "lucide-react";
 import { useChatStore } from "@/stores/useChatStore";
 import { useTranslation } from "@/lib/i18n";
 import { cn } from "@/lib/utils";
@@ -24,6 +24,20 @@ export function ModeToggle() {
       >
         <MessageCircleQuestion className="h-4 w-4" />
         {t("chat.modeAsk")}
+      </button>
+      <button
+        onClick={() => setMode("plan")}
+        disabled={isStreaming}
+        className={cn(
+          "flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md transition-colors",
+          mode === "plan"
+            ? "bg-violet-500 text-white"
+            : "text-muted-foreground hover:text-foreground hover:bg-muted-foreground/10",
+          isStreaming && "opacity-50 cursor-not-allowed"
+        )}
+      >
+        <Map className="h-4 w-4" />
+        {t("chat.modePlan")}
       </button>
       <button
         onClick={() => setMode("build")}

--- a/apps/web/src/components/chat/StreamingMessage.tsx
+++ b/apps/web/src/components/chat/StreamingMessage.tsx
@@ -25,8 +25,32 @@ interface StreamingMessageProps {
   projectId: string;
 }
 
-const COLLAPSE_THRESHOLD = 5; // Number of tool blocks before collapsing
-const VISIBLE_WHEN_COLLAPSED = 2; // Number of items to show at start and end when collapsed
+const COLLAPSE_THRESHOLD = 5;
+const VISIBLE_WHEN_COLLAPSED = 2;
+
+// Tool category definitions with colors
+type ToolCategory = "file" | "search" | "system" | "web" | "agent";
+
+const toolCategoryMap: Record<string, ToolCategory> = {
+  Read: "file",
+  Edit: "file",
+  Write: "file",
+  Glob: "search",
+  Grep: "search",
+  Bash: "system",
+  WebFetch: "web",
+  WebSearch: "web",
+  Task: "agent",
+  TodoWrite: "agent",
+};
+
+const categoryConfig: Record<ToolCategory, { label: string; color: string; border: string; bg: string; text: string }> = {
+  file: { label: "File", color: "text-blue-600 dark:text-blue-400", border: "border-blue-200 dark:border-blue-800", bg: "bg-blue-50 dark:bg-blue-950", text: "text-blue-700 dark:text-blue-300" },
+  search: { label: "Search", color: "text-purple-600 dark:text-purple-400", border: "border-purple-200 dark:border-purple-800", bg: "bg-purple-50 dark:bg-purple-950", text: "text-purple-700 dark:text-purple-300" },
+  system: { label: "System", color: "text-orange-600 dark:text-orange-400", border: "border-orange-200 dark:border-orange-800", bg: "bg-orange-50 dark:bg-orange-950", text: "text-orange-700 dark:text-orange-300" },
+  web: { label: "Web", color: "text-emerald-600 dark:text-emerald-400", border: "border-emerald-200 dark:border-emerald-800", bg: "bg-emerald-50 dark:bg-emerald-950", text: "text-emerald-700 dark:text-emerald-300" },
+  agent: { label: "Agent", color: "text-violet-600 dark:text-violet-400", border: "border-violet-200 dark:border-violet-800", bg: "bg-violet-50 dark:bg-violet-950", text: "text-violet-700 dark:text-violet-300" },
+};
 
 const toolIcons: Record<string, React.ReactNode> = {
   Read: <FileText className="h-4 w-4" />,
@@ -91,6 +115,68 @@ function getToolDescription(block: StreamingBlock): string {
   return "";
 }
 
+const subagentTypeLabels: Record<string, string> = {
+  Explore: "Explore Agent",
+  Plan: "Plan Agent",
+  "general-purpose": "General Agent",
+  Bash: "Bash Agent",
+};
+
+function SubagentBlock({ block }: { block: StreamingBlock }) {
+  const [showResult, setShowResult] = useState(false);
+  const isRunning = block.status === "running";
+  const input = block.tool?.input || {};
+  const agentType = (input.subagent_type as string) || "Agent";
+  const description = (input.description as string) || "";
+  const label = subagentTypeLabels[agentType] || `${agentType} Agent`;
+
+  return (
+    <div className={`rounded-lg border p-3 space-y-1.5 ${
+      isRunning
+        ? "border-violet-200 dark:border-violet-800 bg-violet-50 dark:bg-violet-950"
+        : "border-border bg-muted"
+    }`}>
+      <div className="flex items-center gap-2">
+        {isRunning ? (
+          <Loader2 className="h-4 w-4 animate-spin text-violet-600 dark:text-violet-400" />
+        ) : (
+          <CheckCircle2 className="h-4 w-4 text-green-600" />
+        )}
+        <Bot className={`h-4 w-4 ${isRunning ? "text-violet-600 dark:text-violet-400" : "text-muted-foreground"}`} />
+        <span className={`font-medium text-sm ${isRunning ? "text-violet-700 dark:text-violet-300" : ""}`}>
+          {label}
+        </span>
+        {block.duration !== undefined && (
+          <span className="text-xs text-muted-foreground ml-auto tabular-nums">
+            ({formatDuration(block.duration)})
+          </span>
+        )}
+      </div>
+
+      {description && (
+        <p className={`text-xs pl-10 ${isRunning ? "text-violet-600 dark:text-violet-400" : "text-muted-foreground"}`}>
+          &quot;{description}&quot;
+        </p>
+      )}
+
+      {block.result && !isRunning && (
+        <button
+          onClick={() => setShowResult(!showResult)}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors pl-10 flex items-center gap-1"
+        >
+          {showResult ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+          {showResult ? "결과 숨기기" : "결과 보기"}
+        </button>
+      )}
+      {showResult && block.result && (
+        <div className="pl-10 text-xs text-muted-foreground bg-background rounded p-2 max-h-40 overflow-y-auto whitespace-pre-wrap font-mono">
+          {block.result.length > 500 ? block.result.substring(0, 500) + "..." : block.result}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function TextBlock({ content }: { content: string }) {
   return <MarkdownRenderer content={content} />;
 }
@@ -102,31 +188,37 @@ function formatDuration(ms: number): string {
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
+function getToolCategory(toolName: string): ToolCategory {
+  return toolCategoryMap[toolName] || "system";
+}
+
 function ToolUseBlock({ block }: { block: StreamingBlock }) {
   const isRunning = block.status === "running";
   const toolName = block.tool?.name || "Unknown";
+  const category = getToolCategory(toolName);
+  const config = categoryConfig[category];
 
   return (
     <div
-      className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm ${
+      className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm border ${
         isRunning
-          ? "bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800"
-          : "bg-muted border border-border"
+          ? `${config.bg} ${config.border}`
+          : "bg-muted border-border"
       }`}
     >
       {isRunning ? (
-        <Loader2 className="h-4 w-4 animate-spin text-blue-600 dark:text-blue-400" />
+        <Loader2 className={`h-4 w-4 animate-spin ${config.color}`} />
       ) : (
         <CheckCircle2 className="h-4 w-4 text-green-600" />
       )}
-      <span className={isRunning ? "text-blue-700 dark:text-blue-300" : "text-muted-foreground"}>
+      <span className={isRunning ? config.text : "text-muted-foreground"}>
         {toolIcons[toolName] || <Terminal className="h-4 w-4" />}
       </span>
-      <span className={`font-medium ${isRunning ? "text-blue-800 dark:text-blue-200" : ""}`}>
+      <span className={`font-medium ${isRunning ? config.text : ""}`}>
         {getToolDisplayName(toolName)}
       </span>
       {getToolDescription(block) && (
-        <span className={`truncate flex-1 ${isRunning ? "text-blue-600 dark:text-blue-400" : "text-muted-foreground"}`}>
+        <span className={`truncate flex-1 ${isRunning ? config.color : "text-muted-foreground"}`}>
           {getToolDescription(block)}
         </span>
       )}
@@ -139,8 +231,46 @@ function ToolUseBlock({ block }: { block: StreamingBlock }) {
   );
 }
 
+function ToolSummaryBadges({ blocks }: { blocks: StreamingBlock[] }) {
+  const categoryCounts: Partial<Record<ToolCategory, number>> = {};
+  for (const block of blocks) {
+    const cat = getToolCategory(block.tool?.name || "");
+    categoryCounts[cat] = (categoryCounts[cat] || 0) + 1;
+  }
+
+  const totalDuration = blocks.reduce((sum, b) => sum + (b.duration || 0), 0);
+
+  return (
+    <div className="flex items-center gap-1.5 flex-wrap">
+      {(Object.entries(categoryCounts) as [ToolCategory, number][]).map(([cat, count]) => {
+        const config = categoryConfig[cat];
+        return (
+          <span
+            key={cat}
+            className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium ${config.bg} ${config.text}`}
+          >
+            {config.label} {count}
+          </span>
+        );
+      })}
+      {totalDuration > 0 && (
+        <span className="text-xs text-muted-foreground tabular-nums">
+          ({formatDuration(totalDuration)})
+        </span>
+      )}
+    </div>
+  );
+}
+
 interface ToolBlockGroupProps {
   blocks: StreamingBlock[];
+}
+
+function renderToolBlock(block: StreamingBlock) {
+  if (block.tool?.name === "Task") {
+    return <SubagentBlock key={block.id} block={block} />;
+  }
+  return <ToolUseBlock key={block.id} block={block} />;
 }
 
 function ToolBlockGroup({ blocks }: ToolBlockGroupProps) {
@@ -151,9 +281,8 @@ function ToolBlockGroup({ blocks }: ToolBlockGroupProps) {
   if (!shouldCollapse || isExpanded) {
     return (
       <div className="space-y-1">
-        {blocks.map((block) => (
-          <ToolUseBlock key={block.id} block={block} />
-        ))}
+        {shouldCollapse && <ToolSummaryBadges blocks={blocks} />}
+        {blocks.map(renderToolBlock)}
         {shouldCollapse && isExpanded && (
           <button
             onClick={() => setIsExpanded(false)}
@@ -167,15 +296,13 @@ function ToolBlockGroup({ blocks }: ToolBlockGroupProps) {
     );
   }
 
-  // Show first few, collapse button, then last few
   const firstBlocks = blocks.slice(0, VISIBLE_WHEN_COLLAPSED);
   const lastBlocks = blocks.slice(-VISIBLE_WHEN_COLLAPSED);
 
   return (
     <div className="space-y-1">
-      {firstBlocks.map((block) => (
-        <ToolUseBlock key={block.id} block={block} />
-      ))}
+      <ToolSummaryBadges blocks={blocks} />
+      {firstBlocks.map(renderToolBlock)}
       <button
         onClick={() => setIsExpanded(true)}
         className="flex items-center gap-1 px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors w-full justify-center border border-dashed border-border rounded-md hover:bg-muted/50"
@@ -183,9 +310,7 @@ function ToolBlockGroup({ blocks }: ToolBlockGroupProps) {
         <ChevronDown className="h-4 w-4" />
         <span>{hiddenCount}개 더 보기</span>
       </button>
-      {lastBlocks.map((block) => (
-        <ToolUseBlock key={block.id} block={block} />
-      ))}
+      {lastBlocks.map(renderToolBlock)}
     </div>
   );
 }
@@ -204,17 +329,14 @@ function groupBlocks(blocks: StreamingBlock[]): BlockGroup[] {
     if (block.type === "tool_use") {
       currentToolGroup.push(block);
     } else {
-      // Flush current tool group if exists
       if (currentToolGroup.length > 0) {
         groups.push({ type: "tool_group", blocks: currentToolGroup });
         currentToolGroup = [];
       }
-      // Add non-tool block as single item
       groups.push({ type: "other", blocks: [block] });
     }
   }
 
-  // Flush remaining tool group
   if (currentToolGroup.length > 0) {
     groups.push({ type: "tool_group", blocks: currentToolGroup });
   }
@@ -237,13 +359,11 @@ export function StreamingMessage({ blocks, isStreaming = true, projectId }: Stre
         AI
       </div>
       <div className="flex-1 space-y-2 overflow-hidden">
-        {/* Render block groups */}
         {blockGroups.map((group, groupIndex) => {
           if (group.type === "tool_group") {
             return <ToolBlockGroup key={`group-${groupIndex}`} blocks={group.blocks} />;
           }
 
-          // Render other blocks individually
           return group.blocks.map((block) => {
             if (block.type === "text") {
               return <TextBlock key={block.id} content={block.content || ""} />;
@@ -262,7 +382,6 @@ export function StreamingMessage({ blocks, isStreaming = true, projectId }: Stre
           });
         })}
 
-        {/* Show thinking state when streaming but no blocks yet */}
         {isStreaming && !hasBlocks && (
           <div className="flex items-center gap-2 text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" />
@@ -270,7 +389,6 @@ export function StreamingMessage({ blocks, isStreaming = true, projectId }: Stre
           </div>
         )}
 
-        {/* Show cursor only while streaming */}
         {isStreaming && hasBlocks && (
           <span className="inline-block w-2 h-4 bg-primary animate-pulse" />
         )}

--- a/apps/web/src/components/checkpoint/CheckpointPanel.tsx
+++ b/apps/web/src/components/checkpoint/CheckpointPanel.tsx
@@ -244,41 +244,75 @@ export function CheckpointPanel({ projectId }: CheckpointPanelProps) {
               </div>
             </div>
 
-            {/* Checkpoints */}
-            {checkpoints.map((checkpoint, i) => (
-              <button
-                key={checkpoint.hash}
-                onClick={() => handleSelectCheckpoint(checkpoint)}
-                className={`w-full flex items-start gap-3 p-3 rounded-lg text-left transition-colors ${
-                  selectedCheckpoint?.hash === checkpoint.hash
-                    ? "bg-muted"
-                    : "hover:bg-muted/50"
-                }`}
-              >
-                <div className="relative">
-                  <div className="w-3 h-3 rounded-full bg-muted-foreground/30 mt-1" />
-                  {i < checkpoints.length - 1 && (
-                    <div className="absolute top-4 left-1.5 w-px h-full bg-muted-foreground/20" />
-                  )}
-                </div>
-                <div className="flex-1 min-w-0">
-                  <p className="font-medium text-sm truncate">{checkpoint.message}</p>
-                  <div className="flex items-center gap-2 text-xs text-muted-foreground mt-1">
-                    <Clock className="h-3 w-3" />
-                    {formatTime(checkpoint.timestamp)}
+            {/* Checkpoints timeline */}
+            {checkpoints.map((checkpoint, i) => {
+              const totalChanges = checkpoint.insertions + checkpoint.deletions;
+              const maxBarWidth = 100;
+              const insertBar = totalChanges > 0
+                ? Math.max(1, Math.round((checkpoint.insertions / Math.max(totalChanges, 1)) * maxBarWidth))
+                : 0;
+              const deleteBar = totalChanges > 0
+                ? Math.max(1, maxBarWidth - insertBar)
+                : 0;
+              const isManual = !checkpoint.message.startsWith("Auto checkpoint");
+              const isSelected = selectedCheckpoint?.hash === checkpoint.hash;
+
+              return (
+                <button
+                  key={checkpoint.hash}
+                  onClick={() => handleSelectCheckpoint(checkpoint)}
+                  className={`w-full flex items-start gap-3 p-3 rounded-lg text-left transition-colors ${
+                    isSelected ? "bg-muted" : "hover:bg-muted/50"
+                  }`}
+                >
+                  <div className="relative flex flex-col items-center">
+                    <div
+                      className={`w-3 h-3 rounded-full mt-1 border-2 ${
+                        isManual
+                          ? "bg-primary border-primary"
+                          : isSelected
+                            ? "bg-muted-foreground border-muted-foreground"
+                            : "bg-background border-muted-foreground/40"
+                      }`}
+                    />
+                    {i < checkpoints.length - 1 && (
+                      <div className="w-px flex-1 min-h-[2rem] bg-muted-foreground/20 mt-1" />
+                    )}
                   </div>
-                  {checkpoint.filesChanged > 0 && (
-                    <div className="flex items-center gap-2 text-xs mt-1">
-                      <span className="text-green-500">+{checkpoint.insertions}</span>
-                      <span className="text-red-500">-{checkpoint.deletions}</span>
-                      <span className="text-muted-foreground">
-                        {checkpoint.filesChanged} files
-                      </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium text-sm truncate">{checkpoint.message}</p>
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground mt-1">
+                      <Clock className="h-3 w-3" />
+                      {formatTime(checkpoint.timestamp)}
                     </div>
-                  )}
-                </div>
-              </button>
-            ))}
+                    {checkpoint.filesChanged > 0 && (
+                      <>
+                        <div className="flex items-center gap-2 text-xs mt-1">
+                          <FileText className="h-3 w-3 text-muted-foreground" />
+                          <span className="text-muted-foreground">
+                            {checkpoint.filesChanged} file{checkpoint.filesChanged !== 1 ? "s" : ""}
+                          </span>
+                          <span className="text-green-500">+{checkpoint.insertions}</span>
+                          <span className="text-red-500">-{checkpoint.deletions}</span>
+                        </div>
+                        {totalChanges > 0 && (
+                          <div className="flex h-1.5 rounded-full overflow-hidden mt-1.5 bg-muted" style={{ width: `${Math.min(100, Math.max(20, totalChanges / 2))}%` }}>
+                            <div
+                              className="bg-green-500 h-full"
+                              style={{ width: `${insertBar}%` }}
+                            />
+                            <div
+                              className="bg-red-500 h-full"
+                              style={{ width: `${deleteBar}%` }}
+                            />
+                          </div>
+                        )}
+                      </>
+                    )}
+                  </div>
+                </button>
+              );
+            })}
 
             {checkpoints.length === 0 && (
               <p className="text-sm text-muted-foreground px-3 py-2">

--- a/apps/web/src/components/file/FileViewer.tsx
+++ b/apps/web/src/components/file/FileViewer.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { X, Copy, Check, ExternalLink } from "lucide-react";
-import { useState } from "react";
+import { X, Copy, Check, Save, Pencil, Eye } from "lucide-react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { Highlight, themes } from "prism-react-renderer";
 import { Button } from "@/components/ui/button";
 import { useTranslation } from "@/lib/i18n";
+import { api } from "@/lib/api";
 
 interface FileViewerProps {
   path: string;
   content: string;
   language: string;
+  projectId?: string;
   onClose: () => void;
 }
 
@@ -34,6 +36,8 @@ const languageMap: Record<string, string> = {
   gitignore: "bash",
 };
 
+const binaryExtensions = ["png", "jpg", "jpeg", "gif", "ico", "woff", "woff2", "ttf", "eot", "pdf", "zip"];
+
 function getLanguage(extension: string): string {
   return languageMap[extension] || "typescript";
 }
@@ -42,18 +46,64 @@ function getFileName(path: string): string {
   return path.split("/").pop() || path;
 }
 
-export function FileViewer({ path, content, language, onClose }: FileViewerProps) {
+export function FileViewer({ path, content, language, projectId, onClose }: FileViewerProps) {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editContent, setEditContent] = useState(content);
+  const [isSaving, setIsSaving] = useState(false);
+  const [hasChanges, setHasChanges] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileName = getFileName(path);
   const prismLanguage = getLanguage(language);
-  const lines = content.split("\n");
+  const canEdit = projectId && !binaryExtensions.includes(language);
+
+  useEffect(() => {
+    setHasChanges(editContent !== content);
+  }, [editContent, content]);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(content);
+    await navigator.clipboard.writeText(isEditing ? editContent : content);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
+
+  const handleSave = useCallback(async () => {
+    if (!projectId || !hasChanges) return;
+    setIsSaving(true);
+    try {
+      await api.put(`/projects/${projectId}/files/content`, {
+        path,
+        content: editContent,
+      });
+      setHasChanges(false);
+    } catch (error) {
+      console.error("Failed to save file:", error);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [projectId, path, editContent, hasChanges]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+        e.preventDefault();
+        handleSave();
+      }
+    },
+    [handleSave],
+  );
+
+  const toggleEdit = () => {
+    if (isEditing && hasChanges) {
+      if (!confirm("Discard unsaved changes?")) return;
+      setEditContent(content);
+    }
+    setIsEditing(!isEditing);
+  };
+
+  const displayContent = isEditing ? editContent : content;
+  const lines = displayContent.split("\n");
 
   return (
     <div className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm">
@@ -63,11 +113,41 @@ export function FileViewer({ path, content, language, onClose }: FileViewerProps
           <div className="flex items-center gap-2">
             <span className="font-mono text-sm font-medium">{fileName}</span>
             <span className="text-xs text-muted-foreground">{path}</span>
+            {hasChanges && (
+              <span className="w-2 h-2 rounded-full bg-orange-500" title="Unsaved changes" />
+            )}
           </div>
           <div className="flex items-center gap-1">
             <span className="text-xs text-muted-foreground mr-2">
               {lines.length} lines
             </span>
+            {canEdit && (
+              <Button
+                variant={isEditing ? "default" : "ghost"}
+                size="icon"
+                className="h-8 w-8"
+                onClick={toggleEdit}
+                title={isEditing ? "View mode" : "Edit mode"}
+              >
+                {isEditing ? (
+                  <Eye className="h-4 w-4" />
+                ) : (
+                  <Pencil className="h-4 w-4" />
+                )}
+              </Button>
+            )}
+            {isEditing && hasChanges && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={handleSave}
+                disabled={isSaving}
+                title="Save (Ctrl+S)"
+              >
+                <Save className={`h-4 w-4 ${isSaving ? "animate-spin" : "text-green-500"}`} />
+              </Button>
+            )}
             <Button
               variant="ghost"
               size="icon"
@@ -94,44 +174,55 @@ export function FileViewer({ path, content, language, onClose }: FileViewerProps
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-auto bg-[#1e1e1e]">
-          <Highlight theme={themes.vsDark} code={content} language={prismLanguage}>
-            {({ className, style, tokens, getLineProps, getTokenProps }) => (
-              <pre
-                className="text-sm leading-relaxed"
-                style={{
-                  ...style,
-                  margin: 0,
-                  padding: "1rem",
-                  background: "#1e1e1e",
-                  minHeight: "100%",
-                }}
-              >
-                <code className={className}>
-                  {tokens.map((line, i) => {
-                    const { key: _lineKey, ...lineProps } = getLineProps({ line });
-                    return (
-                      <div
-                        key={i}
-                        {...lineProps}
-                        className="table-row hover:bg-white/5"
-                      >
-                        <span className="table-cell select-none pr-4 text-right text-gray-500 w-12">
-                          {i + 1}
-                        </span>
-                        <span className="table-cell">
-                          {line.map((token, index) => {
-                            const { key: _key, ...tokenProps } = getTokenProps({ token });
-                            return <span key={index} {...tokenProps} />;
-                          })}
-                        </span>
-                      </div>
-                    );
-                  })}
-                </code>
-              </pre>
-            )}
-          </Highlight>
+        <div className="flex-1 overflow-auto bg-[#1e1e1e]" onKeyDown={handleKeyDown}>
+          {isEditing ? (
+            <textarea
+              ref={textareaRef}
+              value={editContent}
+              onChange={(e) => setEditContent(e.target.value)}
+              className="w-full h-full bg-[#1e1e1e] text-zinc-200 font-mono text-sm p-4 resize-none outline-none leading-relaxed"
+              spellCheck={false}
+              autoFocus
+            />
+          ) : (
+            <Highlight theme={themes.vsDark} code={content} language={prismLanguage}>
+              {({ className, style, tokens, getLineProps, getTokenProps }) => (
+                <pre
+                  className="text-sm leading-relaxed"
+                  style={{
+                    ...style,
+                    margin: 0,
+                    padding: "1rem",
+                    background: "#1e1e1e",
+                    minHeight: "100%",
+                  }}
+                >
+                  <code className={className}>
+                    {tokens.map((line, i) => {
+                      const { key: _lineKey, ...lineProps } = getLineProps({ line });
+                      return (
+                        <div
+                          key={i}
+                          {...lineProps}
+                          className="table-row hover:bg-white/5"
+                        >
+                          <span className="table-cell select-none pr-4 text-right text-gray-500 w-12">
+                            {i + 1}
+                          </span>
+                          <span className="table-cell">
+                            {line.map((token, index) => {
+                              const { key: _key, ...tokenProps } = getTokenProps({ token });
+                              return <span key={index} {...tokenProps} />;
+                            })}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </code>
+                </pre>
+              )}
+            </Highlight>
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/preview/ErrorOverlay.tsx
+++ b/apps/web/src/components/preview/ErrorOverlay.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { X, ExternalLink, Copy, Check } from "lucide-react";
+import { X, ExternalLink, Copy, Check, Wand2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
+import { useChatStore } from "@/stores/useChatStore";
 
 export interface ErrorInfo {
   type: "compile" | "runtime" | "network";
@@ -18,10 +19,12 @@ export interface ErrorInfo {
 interface ErrorOverlayProps {
   error: ErrorInfo;
   onDismiss: () => void;
+  projectId?: string;
 }
 
-export function ErrorOverlay({ error, onDismiss }: ErrorOverlayProps) {
+export function ErrorOverlay({ error, onDismiss, projectId }: ErrorOverlayProps) {
   const [copied, setCopied] = useState(false);
+  const { sendMessage, setMode } = useChatStore();
 
   const handleCopy = async () => {
     const text = [
@@ -107,7 +110,25 @@ export function ErrorOverlay({ error, onDismiss }: ErrorOverlayProps) {
           </div>
 
           {/* Footer */}
-          <div className="px-4 py-3 bg-zinc-800/50 border-t border-zinc-700 flex justify-end">
+          <div className="px-4 py-3 bg-zinc-800/50 border-t border-zinc-700 flex justify-end gap-2">
+            {projectId && (
+              <Button
+                size="sm"
+                onClick={() => {
+                  const location = error.location
+                    ? `\nFile: ${error.location.file}:${error.location.line}:${error.location.column}`
+                    : "";
+                  const prompt = `Fix this ${error.type} error:\n${error.message}${location}${error.stack ? `\n\nStack trace:\n${error.stack}` : ""}`;
+                  setMode("build");
+                  sendMessage(projectId, prompt);
+                  onDismiss();
+                }}
+                className="bg-violet-600 hover:bg-violet-700 text-white"
+              >
+                <Wand2 className="h-4 w-4 mr-1" />
+                AI Auto-fix
+              </Button>
+            )}
             <Button
               variant="outline"
               size="sm"

--- a/apps/web/src/components/preview/PreviewPanel.tsx
+++ b/apps/web/src/components/preview/PreviewPanel.tsx
@@ -442,7 +442,7 @@ export function PreviewPanel({ projectId }: PreviewPanelProps) {
             />
             {/* Error Overlay */}
             {buildError && (
-              <ErrorOverlay error={buildError} onDismiss={handleDismissError} />
+              <ErrorOverlay error={buildError} onDismiss={handleDismissError} projectId={projectId} />
             )}
             {/* Device size indicator */}
             {device !== "desktop" && (

--- a/apps/web/src/components/project/CreateProjectModal.tsx
+++ b/apps/web/src/components/project/CreateProjectModal.tsx
@@ -17,6 +17,7 @@ import {
   BackendFramework,
 } from "@claudeship/shared";
 import { useTranslation } from "@/lib/i18n";
+import { ChevronLeft, ChevronRight, Check } from "lucide-react";
 
 interface CreateProjectModalProps {
   open: boolean;
@@ -26,6 +27,7 @@ interface CreateProjectModalProps {
     appType: AppType;
     frontendFramework?: FrontendFramework;
     backendFramework?: BackendFramework;
+    features?: string[];
   }) => void;
   isLoading?: boolean;
 }
@@ -74,7 +76,6 @@ const APP_TYPE_CONFIG = {
   },
 };
 
-// Web frontend frameworks
 const WEB_FRONTENDS = [
   { value: FrontendFramework.REACT_VITE, icon: "⚛️", label: "React + Vite" },
   { value: FrontendFramework.NEXTJS, icon: "▲", label: "Next.js" },
@@ -82,20 +83,39 @@ const WEB_FRONTENDS = [
   { value: FrontendFramework.SVELTE, icon: "🔶", label: "SvelteKit" },
 ];
 
-// Mobile frontend frameworks
 const MOBILE_FRONTENDS = [
   { value: FrontendFramework.EXPO, icon: "📱", label: "Expo" },
   { value: FrontendFramework.REACT_NATIVE, icon: "⚛️", label: "React Native" },
   { value: FrontendFramework.FLUTTER, icon: "🐦", label: "Flutter" },
 ];
 
-// Backend frameworks
 const BACKENDS = [
   { value: BackendFramework.EXPRESS, icon: "🟢", label: "Express" },
   { value: BackendFramework.FASTAPI, icon: "🐍", label: "FastAPI" },
   { value: BackendFramework.DJANGO, icon: "🎸", label: "Django" },
   { value: BackendFramework.NESTJS, icon: "🔴", label: "NestJS" },
 ];
+
+const FEATURE_OPTIONS = [
+  { id: "database-sqlite", group: "Database", label: "SQLite", description: "경량 로컬 DB" },
+  { id: "database-postgres", group: "Database", label: "PostgreSQL", description: "프로덕션 DB" },
+  { id: "auth-nextauth", group: "Auth", label: "NextAuth", description: "인증 (Next.js)" },
+  { id: "auth-passport", group: "Auth", label: "Passport", description: "인증 (Express)" },
+  { id: "ui-shadcn", group: "UI", label: "shadcn/ui", description: "React 컴포넌트" },
+  { id: "ui-tailwind", group: "UI", label: "Tailwind CSS", description: "유틸리티 CSS" },
+  { id: "ui-material", group: "UI", label: "Material UI", description: "Google 디자인" },
+  { id: "test-playwright", group: "Testing", label: "Playwright", description: "E2E 테스트" },
+  { id: "test-jest", group: "Testing", label: "Jest", description: "유닛 테스트" },
+];
+
+type WizardStep = 1 | 2 | 3 | 4;
+
+const STEP_LABELS: Record<WizardStep, string> = {
+  1: "프로젝트 이름 & 타입",
+  2: "프레임워크",
+  3: "기능 선택",
+  4: "확인",
+};
 
 export function CreateProjectModal({
   open,
@@ -104,14 +124,16 @@ export function CreateProjectModal({
   isLoading,
 }: CreateProjectModalProps) {
   const { t } = useTranslation();
+  const [step, setStep] = useState<WizardStep>(1);
   const [name, setName] = useState("");
   const [appType, setAppType] = useState<AppType>(AppType.FULLSTACK_WEB);
   const [frontendFramework, setFrontendFramework] = useState<FrontendFramework>(
-    FrontendFramework.REACT_VITE
+    FrontendFramework.REACT_VITE,
   );
   const [backendFramework, setBackendFramework] = useState<BackendFramework>(
-    BackendFramework.EXPRESS
+    BackendFramework.EXPRESS,
   );
+  const [selectedFeatures, setSelectedFeatures] = useState<string[]>([]);
 
   const config = APP_TYPE_CONFIG[appType];
   const isMobileApp =
@@ -119,14 +141,13 @@ export function CreateProjectModal({
 
   const handleAppTypeChange = (newAppType: AppType) => {
     setAppType(newAppType);
-    // Reset frameworks based on app type
     const newConfig = APP_TYPE_CONFIG[newAppType];
     const isMobile =
       newAppType === AppType.MOBILE || newAppType === AppType.MOBILE_WITH_API;
 
     if (newConfig.showFrontend) {
       setFrontendFramework(
-        isMobile ? FrontendFramework.EXPO : FrontendFramework.REACT_VITE
+        isMobile ? FrontendFramework.EXPO : FrontendFramework.REACT_VITE,
       );
     }
     if (newConfig.showBackend) {
@@ -134,8 +155,13 @@ export function CreateProjectModal({
     }
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
+  const toggleFeature = (id: string) => {
+    setSelectedFeatures((prev) =>
+      prev.includes(id) ? prev.filter((f) => f !== id) : [...prev, id],
+    );
+  };
+
+  const handleSubmit = () => {
     if (!name.trim()) return;
 
     onSubmit({
@@ -143,125 +169,311 @@ export function CreateProjectModal({
       appType,
       frontendFramework: config.showFrontend ? frontendFramework : undefined,
       backendFramework: config.showBackend ? backendFramework : undefined,
+      features: selectedFeatures.length > 0 ? selectedFeatures : undefined,
     });
 
     // Reset form
+    setStep(1);
     setName("");
     setAppType(AppType.FULLSTACK_WEB);
     setFrontendFramework(FrontendFramework.REACT_VITE);
     setBackendFramework(BackendFramework.EXPRESS);
+    setSelectedFeatures([]);
   };
 
+  const canProceed = () => {
+    if (step === 1) return name.trim().length > 0;
+    return true;
+  };
+
+  // Step 2 is skippable if no frontend/backend to choose
+  const shouldSkipStep2 =
+    !config.showFrontend && !config.showBackend;
+
+  const nextStep = () => {
+    if (step === 1 && shouldSkipStep2) {
+      setStep(3);
+    } else if (step < 4) {
+      setStep((step + 1) as WizardStep);
+    }
+  };
+
+  const prevStep = () => {
+    if (step === 3 && shouldSkipStep2) {
+      setStep(1);
+    } else if (step > 1) {
+      setStep((step - 1) as WizardStep);
+    }
+  };
+
+  const featureGroups = FEATURE_OPTIONS.reduce(
+    (acc, f) => {
+      if (!acc[f.group]) acc[f.group] = [];
+      acc[f.group].push(f);
+      return acc;
+    },
+    {} as Record<string, typeof FEATURE_OPTIONS>,
+  );
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={(o) => { if (!o) setStep(1); onOpenChange(o); }}>
       <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
-        <form onSubmit={handleSubmit}>
-          <DialogHeader>
-            <DialogTitle>{t("project.createTitle")}</DialogTitle>
-            <DialogDescription>
-              새 프로젝트의 이름과 타입을 선택하세요
-            </DialogDescription>
-          </DialogHeader>
+        <DialogHeader>
+          <DialogTitle>{t("project.createTitle")}</DialogTitle>
+          <DialogDescription>
+            {STEP_LABELS[step]} ({step}/4)
+          </DialogDescription>
+        </DialogHeader>
 
-          <div className="grid gap-4 py-4">
-            {/* Project Name */}
-            <div className="grid gap-2">
-              <label htmlFor="name" className="text-sm font-medium">
-                {t("project.name")}
-              </label>
-              <Input
-                id="name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder={t("project.namePlaceholder")}
-                autoFocus
-              />
-            </div>
+        {/* Progress bar */}
+        <div className="flex gap-1">
+          {([1, 2, 3, 4] as WizardStep[]).map((s) => (
+            <div
+              key={s}
+              className={`flex-1 h-1 rounded-full transition-colors ${
+                s <= step ? "bg-primary" : "bg-muted"
+              }`}
+            />
+          ))}
+        </div>
 
-            {/* App Type Selection */}
-            <div className="grid gap-2">
-              <label className="text-sm font-medium">앱 타입</label>
-              <div className="grid grid-cols-2 gap-2">
-                {Object.entries(APP_TYPE_CONFIG).map(([type, cfg]) => (
-                  <Button
-                    key={type}
-                    type="button"
-                    variant={appType === type ? "default" : "outline"}
-                    className="h-16 flex-col gap-0.5"
-                    onClick={() => handleAppTypeChange(type as AppType)}
-                  >
-                    <span className="text-lg">{cfg.icon}</span>
-                    <span className="text-xs font-medium">{cfg.label}</span>
-                    <span className="text-[10px] text-muted-foreground">
-                      {cfg.description}
-                    </span>
-                  </Button>
-                ))}
-              </div>
-            </div>
-
-            {/* Frontend Framework Selection */}
-            {config.showFrontend && (
+        <div className="py-2 min-h-[200px]">
+          {/* Step 1: Name & Type */}
+          {step === 1 && (
+            <div className="grid gap-4">
               <div className="grid gap-2">
-                <label className="text-sm font-medium">
-                  {isMobileApp ? "모바일 프레임워크" : "프론트엔드"}
+                <label htmlFor="name" className="text-sm font-medium">
+                  {t("project.name")}
                 </label>
-                <div className="grid grid-cols-4 gap-2">
-                  {(isMobileApp ? MOBILE_FRONTENDS : WEB_FRONTENDS).map((fw) => (
-                    <Button
-                      key={fw.value}
-                      type="button"
-                      variant={
-                        frontendFramework === fw.value ? "default" : "outline"
-                      }
-                      className="h-14 flex-col gap-0.5"
-                      onClick={() => setFrontendFramework(fw.value)}
-                    >
-                      <span className="text-base">{fw.icon}</span>
-                      <span className="text-[10px]">{fw.label}</span>
-                    </Button>
-                  ))}
-                </div>
+                <Input
+                  id="name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder={t("project.namePlaceholder")}
+                  autoFocus
+                />
               </div>
-            )}
 
-            {/* Backend Framework Selection */}
-            {config.showBackend && (
               <div className="grid gap-2">
-                <label className="text-sm font-medium">백엔드</label>
-                <div className="grid grid-cols-4 gap-2">
-                  {BACKENDS.map((fw) => (
+                <label className="text-sm font-medium">앱 타입</label>
+                <div className="grid grid-cols-2 gap-2">
+                  {Object.entries(APP_TYPE_CONFIG).map(([type, cfg]) => (
                     <Button
-                      key={fw.value}
+                      key={type}
                       type="button"
-                      variant={
-                        backendFramework === fw.value ? "default" : "outline"
-                      }
-                      className="h-14 flex-col gap-0.5"
-                      onClick={() => setBackendFramework(fw.value)}
+                      variant={appType === type ? "default" : "outline"}
+                      className="h-16 flex-col gap-0.5"
+                      onClick={() => handleAppTypeChange(type as AppType)}
                     >
-                      <span className="text-base">{fw.icon}</span>
-                      <span className="text-[10px]">{fw.label}</span>
+                      <span className="text-lg">{cfg.icon}</span>
+                      <span className="text-xs font-medium">{cfg.label}</span>
+                      <span className="text-[10px] text-muted-foreground">
+                        {cfg.description}
+                      </span>
                     </Button>
                   ))}
                 </div>
               </div>
+            </div>
+          )}
+
+          {/* Step 2: Framework */}
+          {step === 2 && (
+            <div className="grid gap-4">
+              {config.showFrontend && (
+                <div className="grid gap-2">
+                  <label className="text-sm font-medium">
+                    {isMobileApp ? "모바일 프레임워크" : "프론트엔드"}
+                  </label>
+                  <div className="grid grid-cols-4 gap-2">
+                    {(isMobileApp ? MOBILE_FRONTENDS : WEB_FRONTENDS).map(
+                      (fw) => (
+                        <Button
+                          key={fw.value}
+                          type="button"
+                          variant={
+                            frontendFramework === fw.value
+                              ? "default"
+                              : "outline"
+                          }
+                          className="h-14 flex-col gap-0.5"
+                          onClick={() => setFrontendFramework(fw.value)}
+                        >
+                          <span className="text-base">{fw.icon}</span>
+                          <span className="text-[10px]">{fw.label}</span>
+                        </Button>
+                      ),
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {config.showBackend && (
+                <div className="grid gap-2">
+                  <label className="text-sm font-medium">백엔드</label>
+                  <div className="grid grid-cols-4 gap-2">
+                    {BACKENDS.map((fw) => (
+                      <Button
+                        key={fw.value}
+                        type="button"
+                        variant={
+                          backendFramework === fw.value ? "default" : "outline"
+                        }
+                        className="h-14 flex-col gap-0.5"
+                        onClick={() => setBackendFramework(fw.value)}
+                      >
+                        <span className="text-base">{fw.icon}</span>
+                        <span className="text-[10px]">{fw.label}</span>
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Step 3: Features */}
+          {step === 3 && (
+            <div className="grid gap-4">
+              <p className="text-sm text-muted-foreground">
+                추가할 기능을 선택하세요 (선택 사항)
+              </p>
+              {Object.entries(featureGroups).map(([group, features]) => (
+                <div key={group} className="grid gap-2">
+                  <label className="text-xs font-medium text-muted-foreground uppercase">
+                    {group}
+                  </label>
+                  <div className="flex flex-wrap gap-2">
+                    {features.map((f) => (
+                      <button
+                        key={f.id}
+                        onClick={() => toggleFeature(f.id)}
+                        className={`px-3 py-1.5 rounded-md text-sm border transition-colors ${
+                          selectedFeatures.includes(f.id)
+                            ? "bg-primary text-primary-foreground border-primary"
+                            : "bg-background text-foreground border-border hover:bg-muted"
+                        }`}
+                      >
+                        <span className="font-medium">{f.label}</span>
+                        <span className="text-xs ml-1 opacity-70">
+                          {f.description}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Step 4: Confirm */}
+          {step === 4 && (
+            <div className="grid gap-3">
+              <div className="border rounded-lg p-4 space-y-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-muted-foreground">이름</span>
+                  <span className="font-medium">{name}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-muted-foreground">타입</span>
+                  <span className="font-medium">
+                    {APP_TYPE_CONFIG[appType].icon}{" "}
+                    {APP_TYPE_CONFIG[appType].label}
+                  </span>
+                </div>
+                {config.showFrontend && (
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-muted-foreground">
+                      프론트엔드
+                    </span>
+                    <span className="font-medium">
+                      {
+                        (isMobileApp ? MOBILE_FRONTENDS : WEB_FRONTENDS).find(
+                          (f) => f.value === frontendFramework,
+                        )?.label
+                      }
+                    </span>
+                  </div>
+                )}
+                {config.showBackend && (
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-muted-foreground">
+                      백엔드
+                    </span>
+                    <span className="font-medium">
+                      {BACKENDS.find((f) => f.value === backendFramework)?.label}
+                    </span>
+                  </div>
+                )}
+                {selectedFeatures.length > 0 && (
+                  <div className="flex items-start justify-between">
+                    <span className="text-sm text-muted-foreground">기능</span>
+                    <div className="flex flex-wrap gap-1 justify-end">
+                      {selectedFeatures.map((id) => {
+                        const feature = FEATURE_OPTIONS.find(
+                          (f) => f.id === id,
+                        );
+                        return (
+                          <span
+                            key={id}
+                            className="px-2 py-0.5 rounded text-xs bg-muted"
+                          >
+                            {feature?.label}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="flex items-center justify-between gap-2">
+          <div>
+            {step > 1 && (
+              <Button type="button" variant="ghost" size="sm" onClick={prevStep}>
+                <ChevronLeft className="h-4 w-4 mr-1" />
+                이전
+              </Button>
             )}
           </div>
-
-          <DialogFooter>
+          <div className="flex gap-2">
             <Button
               type="button"
               variant="outline"
-              onClick={() => onOpenChange(false)}
+              onClick={() => { setStep(1); onOpenChange(false); }}
             >
               {t("common.cancel")}
             </Button>
-            <Button type="submit" disabled={!name.trim() || isLoading}>
-              {isLoading ? t("common.loading") : t("common.create")}
-            </Button>
-          </DialogFooter>
-        </form>
+            {step < 4 ? (
+              <Button
+                type="button"
+                onClick={nextStep}
+                disabled={!canProceed()}
+              >
+                다음
+                <ChevronRight className="h-4 w-4 ml-1" />
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                onClick={handleSubmit}
+                disabled={!name.trim() || isLoading}
+              >
+                {isLoading ? (
+                  t("common.loading")
+                ) : (
+                  <>
+                    <Check className="h-4 w-4 mr-1" />
+                    {t("common.create")}
+                  </>
+                )}
+              </Button>
+            )}
+          </div>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/src/components/terminal/TerminalPanel.tsx
+++ b/apps/web/src/components/terminal/TerminalPanel.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { Terminal, Trash2, Square, Send } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface TerminalPanelProps {
+  projectId: string;
+}
+
+interface OutputLine {
+  id: number;
+  type: "stdout" | "stderr" | "input" | "exit";
+  content: string;
+}
+
+export function TerminalPanel({ projectId }: TerminalPanelProps) {
+  const [input, setInput] = useState("");
+  const [output, setOutput] = useState<OutputLine[]>([]);
+  const [isRunning, setIsRunning] = useState(false);
+  const [history, setHistory] = useState<string[]>([]);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  const outputRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const lineIdRef = useRef(0);
+
+  const scrollToBottom = useCallback(() => {
+    if (outputRef.current) {
+      outputRef.current.scrollTop = outputRef.current.scrollHeight;
+    }
+  }, []);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [output, scrollToBottom]);
+
+  const addLine = (type: OutputLine["type"], content: string) => {
+    setOutput((prev) => [
+      ...prev,
+      { id: lineIdRef.current++, type, content },
+    ]);
+  };
+
+  const executeCommand = async (command: string) => {
+    if (!command.trim() || isRunning) return;
+
+    setHistory((prev) => [...prev, command]);
+    setHistoryIndex(-1);
+    addLine("input", `$ ${command}`);
+    setInput("");
+    setIsRunning(true);
+
+    try {
+      const apiBase =
+        process.env.NEXT_PUBLIC_API_URL || "http://localhost:14000/api";
+      const response = await fetch(
+        `${apiBase}/projects/${projectId}/terminal/execute`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ command }),
+        },
+      );
+
+      if (!response.ok) {
+        addLine("stderr", `Error: ${response.statusText}`);
+        setIsRunning(false);
+        return;
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) {
+        setIsRunning(false);
+        return;
+      }
+
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          if (line.startsWith("data: ")) {
+            const data = line.slice(6);
+            if (data === "[DONE]") continue;
+
+            try {
+              const event = JSON.parse(data);
+              if (event.type === "stdout" && event.data) {
+                addLine("stdout", event.data);
+              } else if (event.type === "stderr" && event.data) {
+                addLine("stderr", event.data);
+              } else if (event.type === "exit") {
+                if (event.exitCode !== 0) {
+                  addLine("exit", `Process exited with code ${event.exitCode}`);
+                }
+              }
+            } catch {
+              // Ignore parse errors
+            }
+          }
+        }
+      }
+    } catch (error) {
+      addLine("stderr", `Failed to execute: ${error instanceof Error ? error.message : "Unknown error"}`);
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      executeCommand(input);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (history.length > 0) {
+        const newIndex = historyIndex === -1 ? history.length - 1 : Math.max(0, historyIndex - 1);
+        setHistoryIndex(newIndex);
+        setInput(history[newIndex]);
+      }
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (historyIndex >= 0) {
+        const newIndex = historyIndex + 1;
+        if (newIndex >= history.length) {
+          setHistoryIndex(-1);
+          setInput("");
+        } else {
+          setHistoryIndex(newIndex);
+          setInput(history[newIndex]);
+        }
+      }
+    }
+  };
+
+  const handleKill = async () => {
+    try {
+      const apiBase =
+        process.env.NEXT_PUBLIC_API_URL || "http://localhost:14000/api";
+      await fetch(`${apiBase}/projects/${projectId}/terminal/kill`, {
+        method: "DELETE",
+      });
+    } catch {
+      // Ignore
+    }
+  };
+
+  const handleClear = () => {
+    setOutput([]);
+    lineIdRef.current = 0;
+  };
+
+  return (
+    <div
+      className="flex flex-col h-full bg-zinc-950 text-zinc-200"
+      onClick={() => inputRef.current?.focus()}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-zinc-800">
+        <div className="flex items-center gap-2 text-sm">
+          <Terminal className="h-4 w-4" />
+          Terminal
+        </div>
+        <div className="flex gap-1">
+          {isRunning && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleKill}
+              className="h-6 text-xs text-red-400 hover:text-red-300 hover:bg-zinc-800"
+            >
+              <Square className="h-3 w-3 mr-1" />
+              Kill
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleClear}
+            className="h-6 text-xs text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800"
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Output */}
+      <div
+        ref={outputRef}
+        className="flex-1 overflow-y-auto p-3 font-mono text-sm space-y-0.5"
+      >
+        {output.length === 0 ? (
+          <div className="text-zinc-600 text-xs">
+            Type a command and press Enter to execute.
+          </div>
+        ) : (
+          output.map((line) => (
+            <div
+              key={line.id}
+              className={`whitespace-pre-wrap break-all ${
+                line.type === "stderr"
+                  ? "text-red-400"
+                  : line.type === "input"
+                    ? "text-green-400"
+                    : line.type === "exit"
+                      ? "text-yellow-400"
+                      : "text-zinc-200"
+              }`}
+            >
+              {line.content}
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Input */}
+      <div className="flex items-center gap-2 px-3 py-2 border-t border-zinc-800">
+        <span className="text-green-400 font-mono text-sm">$</span>
+        <input
+          ref={inputRef}
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={isRunning ? "Running..." : "Enter command..."}
+          disabled={isRunning}
+          className="flex-1 bg-transparent text-sm font-mono text-zinc-200 placeholder:text-zinc-600 outline-none"
+          autoFocus
+        />
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => executeCommand(input)}
+          disabled={isRunning || !input.trim()}
+          className="h-6 text-xs text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800"
+        >
+          <Send className="h-3 w-3" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/workspace/WorkspaceLayout.tsx
+++ b/apps/web/src/components/workspace/WorkspaceLayout.tsx
@@ -11,6 +11,8 @@ import { CheckpointPanel } from "@/components/checkpoint/CheckpointPanel";
 import { EnvPanel } from "@/components/env/EnvPanel";
 import { ArchitectPanel } from "@/components/architect/ArchitectPanel";
 import { ProjectContextPanel } from "@/components/project-context/ProjectContextPanel";
+import { AgentPanel } from "@/components/agent/AgentPanel";
+import { TerminalPanel } from "@/components/terminal/TerminalPanel";
 import {
   FolderTree,
   X,
@@ -21,6 +23,8 @@ import {
   Settings2,
   Search,
   FileText,
+  Bot,
+  Terminal,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useTranslation } from "@/lib/i18n";
@@ -35,7 +39,7 @@ interface SelectedFile {
   extension: string;
 }
 
-type RightPanelTab = "preview" | "database" | "testing" | "checkpoint" | "env" | "review" | "context";
+type RightPanelTab = "preview" | "database" | "testing" | "checkpoint" | "env" | "review" | "context" | "agents" | "terminal";
 
 const tabConfig: { id: RightPanelTab; icon: React.ReactNode; label: string }[] = [
   { id: "preview", icon: <Eye className="h-4 w-4" />, label: "Preview" },
@@ -45,6 +49,8 @@ const tabConfig: { id: RightPanelTab; icon: React.ReactNode; label: string }[] =
   { id: "checkpoint", icon: <GitBranch className="h-4 w-4" />, label: "Checkpoint" },
   { id: "env", icon: <Settings2 className="h-4 w-4" />, label: "Env" },
   { id: "context", icon: <FileText className="h-4 w-4" />, label: "Context" },
+  { id: "agents", icon: <Bot className="h-4 w-4" />, label: "Agents" },
+  { id: "terminal", icon: <Terminal className="h-4 w-4" />, label: "Terminal" },
 ];
 
 export function WorkspaceLayout({ projectId }: WorkspaceLayoutProps) {
@@ -78,6 +84,10 @@ export function WorkspaceLayout({ projectId }: WorkspaceLayoutProps) {
         return <ArchitectPanel projectId={projectId} />;
       case "context":
         return <ProjectContextPanel projectId={projectId} />;
+      case "agents":
+        return <AgentPanel projectId={projectId} />;
+      case "terminal":
+        return <TerminalPanel projectId={projectId} />;
       default:
         return <PreviewPanel projectId={projectId} />;
     }
@@ -151,6 +161,7 @@ export function WorkspaceLayout({ projectId }: WorkspaceLayoutProps) {
           path={selectedFile.path}
           content={selectedFile.content}
           language={selectedFile.extension}
+          projectId={projectId}
           onClose={handleCloseViewer}
         />
       )}

--- a/apps/web/src/lib/i18n/translations/en.json
+++ b/apps/web/src/lib/i18n/translations/en.json
@@ -50,7 +50,9 @@
     "toolCompleted": "Completed",
     "newConversation": "New Chat",
     "modeAsk": "Ask",
-    "modeBuild": "Build"
+    "modePlan": "Plan",
+    "modeBuild": "Build",
+    "planPlaceholder": "Ask to plan the implementation..."
   },
   "preview": {
     "title": "Preview",

--- a/apps/web/src/lib/i18n/translations/ko.json
+++ b/apps/web/src/lib/i18n/translations/ko.json
@@ -50,7 +50,9 @@
     "toolCompleted": "완료",
     "newConversation": "새 대화",
     "modeAsk": "Ask",
-    "modeBuild": "Build"
+    "modePlan": "Plan",
+    "modeBuild": "Build",
+    "planPlaceholder": "구현 계획을 세워달라고 요청하세요..."
   },
   "preview": {
     "title": "미리보기",

--- a/apps/web/src/stores/useChatStore.ts
+++ b/apps/web/src/stores/useChatStore.ts
@@ -58,6 +58,10 @@ interface ChatState {
   pendingQuestion: AskUserQuestionData | null;
   attachedFiles: AttachedFile[];
   isUploading: boolean;
+  sessionId: string | null;
+  lastCost: number | null;
+  totalCost: number;
+  streamStartedAt: number | null;
 
   initForProject: (projectId: string) => void;
   fetchMessages: (projectId: string) => Promise<void>;
@@ -89,6 +93,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
   pendingQuestion: null,
   attachedFiles: [],
   isUploading: false,
+  sessionId: null,
+  lastCost: null,
+  totalCost: 0,
+  streamStartedAt: null,
 
   initForProject: (projectId: string) => {
     const files = get().attachedFiles;
@@ -458,7 +466,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set({
       isStreaming: true,
       streamingBlocks: [],
-      error: null
+      error: null,
+      streamStartedAt: Date.now(),
     });
 
     try {
@@ -524,7 +533,17 @@ export const useChatStore = create<ChatState>((set, get) => ({
                 return;
               }
 
-              if (data.type === "text" && data.content) {
+              if (data.type === "init" && data.sessionId) {
+                set({ sessionId: data.sessionId });
+              } else if (data.type === "complete") {
+                const cost = data.cost as number | undefined;
+                if (cost) {
+                  set((state) => ({
+                    lastCost: cost,
+                    totalCost: state.totalCost + cost,
+                  }));
+                }
+              } else if (data.type === "text" && data.content) {
                 // Check for restart-preview marker
                 const hasRestartMarker = RESTART_MARKER_REGEX.test(data.content);
                 // Reset regex lastIndex after test()

--- a/design/phase-002/001-overview.md
+++ b/design/phase-002/001-overview.md
@@ -1,268 +1,213 @@
-# Phase 002: 기능 고도화 Overview
+# Phase 002: Claude Code 모드 노출 및 개발 생산성 기능
 
-> 작성일: 2025-12-30
-> 상태: 진행 중
+> 작성일: 2026-02-17
+> 상태: 구현 완료
+> Issue: #94
+> 브랜치: `feature/#94-phase002-claude-code-modes`
 
 ---
 
 ## 1. Phase 002 목표
 
-Phase 001에서 구현된 기능들이 **실제로 동작하지 않거나 불완전한 상태**입니다. Phase 002의 목표는:
+Phase 001의 버그 수정(PR #84)이 완료된 후, Phase 002는 **신규 기능 개발**에 집중합니다.
 
-1. **기존 기능 정상화** - 구현되었지만 동작하지 않는 기능들 수정
-2. **기능 고도화** - 기본 구현에서 실용적인 수준으로 개선
-3. **추가 기능 식별** - 리플릿 등 유사 서비스 대비 누락된 기능 파악
+### 핵심 전략
+> **Claude Code CLI의 강력한 기능을 웹 UI로 노출 + 클린 코드 자동화**
+
+Replit Agent 대비 ClaudeShip의 포지셔닝: **"Claude Code를 가장 잘 활용하는 웹 IDE"**
+
+### 왜 이 전략인가?
+
+```mermaid
+flowchart LR
+    subgraph Replit
+        R1[300+ AI 모델]
+        R2[배포/호스팅]
+        R3[멀티플레이어]
+        R4[모바일 앱]
+    end
+
+    subgraph ClaudeShip
+        C1[Claude Code CLI 직접 통합]
+        C2[Plan/Build/Ask 모드]
+        C3[서브에이전트 시각화]
+        C4[클린 코드 자동화]
+    end
+
+    style ClaudeShip fill:#e8f5e9
+    style Replit fill:#fff3e0
+```
+
+- Replit은 범용 클라우드 IDE → 전체 인프라/모델 경쟁에서 이기기 어려움
+- ClaudeShip은 Claude Code CLI를 **백엔드 엔진**으로 직접 사용 → CLI의 모든 기능을 웹에서 활용
+- Replit의 약점(지저분한 코드 생성)을 클린 코드 전략으로 차별화
 
 ---
 
-## 2. 현재 상황 분석
+## 2. Phase 001 버그 수정 현황
 
-### 2.1 API 테스트 결과 (2025-01-xx)
+> PR #84에서 해결 완료
 
-| 기능 | 백엔드 | 프론트엔드 | API 상태 | 실사용 상태 | 문제점 |
-|------|--------|-----------|----------|------------|--------|
-| **Checkpoint** | ✅ 있음 | ✅ 있음 | ✅ 응답함 | ❌ 미동작 | 체크포인트 기록이 안됨 |
-| **Architect (Review)** | ✅ 있음 | ✅ 있음 | ✅ 응답함 | ⚠️ 불확실 | 리뷰 결과 반영 확인 필요 |
-| **Database Viewer** | ✅ 있음 | ✅ 있음 | ❌ 500에러 | ❌ 미동작 | DB 없는 프로젝트 에러 처리 미흡 |
-| **Testing (E2E)** | ✅ 있음 | ✅ 있음 | ✅ 응답함 | ⚠️ 미확인 | 실제 테스트 실행 필요 |
-| **Env Manager** | ✅ 있음 | ✅ 있음 | ✅ 응답함 | ⚠️ 미확인 | UI 동작 확인 필요 |
-| **Project Context** | ✅ 있음 | ❌ 없음 | ✅ 응답함 | ❌ 미동작 | UI 없음 |
+| 작업 | 설명 | 상태 |
+|------|------|------|
+| P2-001 | build.complete 이벤트 디버깅 | ✅ 완료 |
+| P2-002 | Database Viewer 500 에러 수정 | ✅ 완료 |
+| P2-003 | Checkpoint Git 초기화 로직 수정 | ✅ 완료 |
+| P2-004 | Architect Review 트리거 수정 | ✅ 완료 |
+| P2-005 | Project Context UI 구현 | ✅ 완료 |
+| P2-006~010 | 기타 버그 수정 및 고도화 | ✅ 완료 |
 
-#### API 테스트 상세 결과
+---
 
-```bash
-# Checkpoint - API 응답하지만 실제 기록 안됨
-GET /api/projects/:id/checkpoint → [] (빈 배열)
-GET /api/projects/:id/checkpoint/status → {"hasChanges":false,"files":[]}
+## 3. Phase 002 신규 기능 목록
 
-# Architect Review - API 응답
-GET /api/projects/:id/architect/reviews → 리뷰 목록 반환
+### 3.1 1단계: Claude Code 모드 노출 (핵심)
 
-# Database Viewer - 500 에러
-GET /api/projects/:id/database/tables → {"statusCode":500,"message":"Internal server error"}
+| ID | 기능 | 설명 | 설계 문서 |
+|----|------|------|-----------|
+| P2-011 | Plan Mode 지원 | Plan/Build/Ask 3단 모드 토글 | [002-feature-gap-analysis.md](./002-feature-gap-analysis.md) |
+| P2-012 | 상태 대시보드 | 세션, 도구, 토큰, 비용 실시간 표시 | [003-claude-mode-features.md](./003-claude-mode-features.md) |
+| P2-013 | 도구 시각화 개선 | 카테고리별 색상, 요약 배지, 통계 | [003-claude-mode-features.md](./003-claude-mode-features.md) |
 
-# Testing (E2E) - API 응답
-GET /api/projects/:id/testing/scenarios → [] (빈 배열)
+### 3.2 2단계: 개발 생산성
 
-# Env Manager - API 응답
-GET /api/projects/:id/env → .env 파일 목록 및 변수 반환
+| ID | 기능 | 설명 | 설계 문서 |
+|----|------|------|-----------|
+| P2-014 | 웹 터미널 | xterm.js + node-pty | [004-dev-productivity.md](./004-dev-productivity.md) |
+| P2-015 | 파일 편집기 | Monaco/CodeMirror 통합 | [004-dev-productivity.md](./004-dev-productivity.md) |
+| P2-022 | 에러→AI 자동수정 | 에러 감지→채팅 전달→수정 | [004-dev-productivity.md](./004-dev-productivity.md) |
 
-# Project Context - API 응답
-GET /api/projects/:id/context/exists → {"exists":false,"content":null}
-```
+### 3.3 3단계: AI 에이전트 고도화
 
-### 2.2 공통 문제점
+| ID | 기능 | 설명 | 설계 문서 |
+|----|------|------|-----------|
+| P2-017 | Architect 고도화 | 보안 스캔, 코드 구조 분석, Fix with Agent | [005-agent-enhancement.md](./005-agent-enhancement.md) |
+| P2-018 | 서브에이전트 UI | 활성 에이전트 목록, 진행 상태, 결과 요약 | [005-agent-enhancement.md](./005-agent-enhancement.md) |
+| P2-019 | 커스텀 에이전트 관리 | .claude/agents/ YAML 관리 UI | [005-agent-enhancement.md](./005-agent-enhancement.md) |
+
+### 3.4 4단계: 완성도
+
+| ID | 기능 | 설명 | 설계 문서 |
+|----|------|------|-----------|
+| P2-020 | 체크포인트 개선 | 시각적 타임라인, 미리보기 | [006-polish-features.md](./006-polish-features.md) |
+| P2-021 | 설정 마법사 | 템플릿, AI 추천, 보일러플레이트 | [006-polish-features.md](./006-polish-features.md) |
+
+### 제외
+- ~~P2-016: 배포 기능 (Vercel/Netlify)~~ — 스코프 제외
+
+---
+
+## 4. 클린 코드 전략 (Replit 차별화)
+
+Replit Agent의 문제: **코드 구조가 지저분함** (God component, 중복 코드, flat 구조)
 
 ```mermaid
 flowchart TB
-    A[Phase 001 구현] --> B{문제점}
-    B --> C[API 연동 불일치]
-    B --> D[통합 테스트 부재]
-    B --> E[에러 핸들링 미흡]
-    B --> F[UI/UX 미완성]
+    subgraph "레이어 1: 예방"
+        P1[PromptBuilderService 규칙 주입]
+        P2[PROJECT.md 자동 생성]
+        P3[컨벤션 강제]
+    end
 
-    C --> G[프론트엔드 API 경로와 백엔드 라우트 불일치]
-    D --> H[실제 사용 시나리오 테스트 안됨]
-    E --> I[에러 시 사용자에게 피드백 없음]
-    F --> J[일부 기능 UI 미구현]
+    subgraph "레이어 2: 감지"
+        D1[빌드 후 자동 구조 분석]
+        D2[파일 크기/폴더 깊이 체크]
+        D3[점수화 + 개선 제안]
+    end
+
+    subgraph "레이어 3: 자동 정리"
+        R1["정리해줘" 원클릭 리팩토링]
+        R2[파일 분리/import 정리]
+        R3[네이밍 통일]
+    end
+
+    P1 --> D1
+    D1 --> R1
+
+    style P1 fill:#e3f2fd
+    style D1 fill:#fff3e0
+    style R1 fill:#e8f5e9
 ```
 
-### 2.3 기능별 상세 분석
-
-#### Checkpoint (체크포인트)
-- **백엔드**: `apps/server/src/checkpoint/`
-- **프론트엔드**: `CheckpointPanel.tsx`
-- **확인된 문제**:
-  - ❌ **체크포인트 기록이 실제로 생성되지 않음**
-  - 빈 배열만 반환됨 - 저장 로직 또는 트리거 확인 필요
-  - 수동 저장 버튼 동작 확인 필요
-
-#### Architect (코드 리뷰)
-- **백엔드**: `apps/server/src/architect/`
-- **프론트엔드**: `ArchitectPanel.tsx`
-- **확인된 문제**:
-  - ⚠️ **리뷰 결과가 실제로 반영되는지 불확실**
-  - API는 응답하지만 리뷰 트리거 및 결과 반영 확인 필요
-  - Claude CLI 연동 상태 확인 필요
-
-#### Database Viewer (DB 뷰어)
-- **백엔드**: `apps/server/src/database/`
-- **프론트엔드**: `DatabasePanel.tsx`
-- **확인된 문제**:
-  - ❌ **500 Internal Server Error 발생**
-  - DB가 없는 프로젝트에서 적절한 에러 메시지 대신 500 에러 반환
-  - NotFoundException 처리가 제대로 안 됨
-
-#### Testing (E2E 테스팅)
-- **백엔드**: `apps/server/src/testing/`
-- **프론트엔드**: `TestRunner.tsx`
-- **확인된 문제**:
-  - ⚠️ **API는 응답하지만 실제 테스트 실행 확인 필요**
-  - Playwright 의존성 및 설치 상태 확인 필요
-  - 시나리오 저장이 메모리 기반인지 DB 기반인지 확인 필요
-
-#### Env Manager (환경변수)
-- **백엔드**: `apps/server/src/env/`
-- **프론트엔드**: `EnvPanel.tsx`
-- **확인된 문제**:
-  - ✅ **API 정상 동작 확인**
-  - .env 파일 목록 및 변수 반환됨
-  - UI 연동 상태 추가 확인 필요
-
-#### Project Context (프로젝트 컨텍스트)
-- **백엔드**: `apps/server/src/project-context/`
-- **프론트엔드**: ❌ 없음
-- **확인된 문제**:
-  - ✅ **API 정상 동작** (`exists: false` 적절히 반환)
-  - ❌ **UI가 전혀 없음** - 백엔드만 있음
+| 레이어 | 적용 기능 |
+|--------|-----------|
+| 예방 (프롬프트) | P2-011, P2-021 |
+| 감지 (Architect) | P2-017 |
+| 자동 정리 (리팩토링) | P2-017, P2-019 |
 
 ---
 
-## 2.4 핵심 이벤트 분석
+## 5. 아키텍처 개요
 
-### build.complete 이벤트
+### 현재 시스템 구조
 
-체크포인트와 코드리뷰 기능은 모두 `build.complete` 이벤트에 의존합니다:
+```mermaid
+flowchart TB
+    subgraph Frontend["프론트엔드 (Next.js)"]
+        Chat[ChatPanel]
+        ModeToggle[ModeToggle]
+        StatusBar[ClaudeStatusBar]
+        Preview[PreviewPanel]
+        Architect[ArchitectPanel]
+        Checkpoint[CheckpointPanel]
+        Terminal[TerminalPanel - NEW]
+        Editor[FileEditor - NEW]
+    end
+
+    subgraph Backend["백엔드 (NestJS)"]
+        ChatSvc[ChatService]
+        ClaudeCLI[ClaudeCliService]
+        ArchSvc[ArchitectService]
+        CheckSvc[CheckpointService]
+        PreviewSvc[PreviewService]
+        TermSvc[TerminalService - NEW]
+    end
+
+    subgraph External["외부"]
+        Claude[Claude Code CLI]
+    end
+
+    Chat --> ChatSvc
+    ChatSvc --> ClaudeCLI
+    ClaudeCLI --> Claude
+    ChatSvc --"build.complete"--> ArchSvc
+    ChatSvc --"build.complete"--> CheckSvc
+
+    style Terminal fill:#fff9c4
+    style Editor fill:#fff9c4
+    style TermSvc fill:#fff9c4
+    style StatusBar fill:#fff9c4
+```
+
+### 데이터 흐름 (SSE 기반)
 
 ```mermaid
 sequenceDiagram
     participant User
-    participant ChatService
-    participant ClaudeCLI
-    participant EventEmitter
-    participant Checkpoint
-    participant Architect
+    participant Web as Frontend
+    participant API as Backend
+    participant CLI as Claude CLI
 
-    User->>ChatService: sendMessage(mode="build")
-    ChatService->>ClaudeCLI: executePrompt()
-    ClaudeCLI-->>ChatService: tool_use events (Write, Edit...)
-    ChatService->>ChatService: toolActivities.push()
-    ClaudeCLI-->>ChatService: complete
-    ChatService->>EventEmitter: emit("build.complete")
-    EventEmitter->>Checkpoint: handleBuildComplete()
-    EventEmitter->>Architect: handleBuildComplete()
-```
+    User->>Web: 메시지 입력 (mode=plan/build/ask)
+    Web->>API: POST /projects/:id/chat (SSE)
+    API->>CLI: spawn claude -p "prompt" --tools MODE_TOOLS
+    CLI-->>API: stream-json events (init, text, tool_use, complete)
+    API-->>Web: SSE data events
+    Web-->>User: 실시간 스트리밍 렌더링
 
-**발생 조건**:
-- `mode === "build"` (기본값)
-- `toolActivities.length > 0` (Write, Edit 등 도구 사용)
-
-**문제 가능성**:
-1. Claude CLI의 `tool_use` 이벤트가 파싱되지 않음
-2. 프로젝트에 Git 초기화가 안됨
-3. 이벤트 전달 과정에서 누락
-
----
-
-## 3. Phase 002 작업 목록
-
-### 3.1 우선순위 1: 핵심 기능 정상화
-
-| 작업 | 설명 | 난이도 | 상태 |
-|------|------|--------|------|
-| **P2-001** | build.complete 이벤트 디버깅 | 고 | 대기 |
-| **P2-002** | Database Viewer 500 에러 수정 | 저 | 대기 |
-| **P2-003** | Checkpoint Git 초기화 로직 확인 | 중 | 대기 |
-| **P2-004** | Architect Review 트리거 확인 | 중 | 대기 |
-
-### 3.2 우선순위 2: 기능 완성
-
-| 작업 | 설명 | 난이도 | 상태 |
-|------|------|--------|------|
-| **P2-005** | Project Context UI 구현 | 중 | 대기 |
-| **P2-006** | Testing 기능 E2E 확인 | 중 | 대기 |
-| **P2-007** | 에러 핸들링 개선 (500 → 적절한 HTTP 코드) | 중 | 대기 |
-
-### 3.3 우선순위 3: 고도화
-
-| 작업 | 설명 | 난이도 | 상태 |
-|------|------|--------|------|
-| **P2-008** | Checkpoint 자동 저장 | 중 | 대기 |
-| **P2-009** | Database Viewer SQL 에디터 개선 | 중 | 대기 |
-| **P2-010** | Review 결과 요약 대시보드 | 중 | 대기 |
-
----
-
-## 4. 추가 기능 후보 (리플릿 참조)
-
-### 4.1 리플릿 주요 기능 비교
-
-| 리플릿 기능 | ClaudeShip 현황 | 우선순위 |
-|------------|----------------|---------|
-| **Deployment** | ❌ 없음 | 높음 |
-| **Custom Domain** | ❌ 없음 | 중간 |
-| **Secrets Management** | ⚠️ Env로 일부 대체 | 낮음 |
-| **Multiplayer Editing** | ❌ 없음 | 낮음 |
-| **AI Chat History** | ✅ 있음 | - |
-| **File Editing** | ✅ 있음 (조회만) | 중간 |
-| **Shell/Terminal** | ❌ 없음 | 높음 |
-| **Package Manager UI** | ❌ 없음 | 중간 |
-| **Preview URL Sharing** | ❌ 없음 | 중간 |
-
-### 4.2 추가 기능 후보 목록
-
-```mermaid
-flowchart LR
-    A[Phase 002 추가 기능] --> B[터미널]
-    A --> C[배포]
-    A --> D[패키지 관리]
-    A --> E[파일 편집]
-
-    B --> B1[내장 터미널]
-    C --> C1[Vercel/Netlify 연동]
-    D --> D1[package.json UI]
-    E --> E1[Monaco Editor 통합]
-```
-
-#### 높음 우선순위
-1. **터미널** - 웹 기반 터미널 (xterm.js)
-2. **배포** - Vercel/Netlify 원클릭 배포
-
-#### 중간 우선순위
-3. **파일 편집** - 파일 탐색기에서 직접 편집
-4. **패키지 관리** - 의존성 추가/제거 UI
-
-#### 낮음 우선순위
-5. **Preview URL 공유** - 외부 접근 가능한 URL
-6. **멀티플레이어** - 실시간 협업
-
----
-
-## 5. Phase 002 로드맵
-
-```mermaid
-gantt
-    title Phase 002 로드맵
-    dateFormat X
-    axisFormat %s
-
-    section 1단계: 정상화
-    Checkpoint 수정       :a1, 0, 2
-    Database Viewer 수정  :a2, after a1, 2
-    Env Manager 수정      :a3, after a1, 1
-
-    section 2단계: 완성
-    Project Context UI    :b1, after a2, 2
-    Architect Review 수정 :b2, after a3, 3
-    에러 핸들링 개선      :b3, after b1, 2
-
-    section 3단계: 고도화
-    자동 체크포인트       :c1, after b2, 2
-    터미널 기능           :c2, after b3, 3
+    Note over API,CLI: build.complete 이벤트
+    API->>API: emit("build.complete")
+    API-->>API: Architect → 자동 리뷰
+    API-->>API: Checkpoint → 자동 저장
 ```
 
 ---
 
-## 6. 다음 단계
+## 6. 관련 문서
 
-1. **기능별 상세 분석 문서 작성** - 각 기능의 현재 문제점과 수정 방향
-2. **테스트 시나리오 작성** - 기능별 정상 동작 확인 기준
-3. **작업 착수** - 우선순위 순으로 수정 진행
-
----
-
-## 7. 관련 문서
-
-- [Phase 001 문서들](../phase-001/) - 기존 설계 문서
-- 002-checkpoint-fix.md (예정) - 체크포인트 수정 상세
-- 003-database-viewer-fix.md (예정) - DB 뷰어 수정 상세
+- [Phase 001 문서들](../phase-001/) - MVP 설계 문서
+- [002-feature-gap-analysis.md](./002-feature-gap-analysis.md) - Replit/Claude Code 비교 분석
+- [003-claude-mode-features.md](./003-claude-mode-features.md) - 1단계 기능 상세 설계
+- [004-dev-productivity.md](./004-dev-productivity.md) - 2단계 기능 상세 설계
+- [005-agent-enhancement.md](./005-agent-enhancement.md) - 3단계 기능 상세 설계
+- [006-polish-features.md](./006-polish-features.md) - 4단계 기능 상세 설계

--- a/design/phase-002/002-feature-gap-analysis.md
+++ b/design/phase-002/002-feature-gap-analysis.md
@@ -1,0 +1,176 @@
+# Phase 002: 기능 갭 분석 - Replit vs Claude Code vs ClaudeShip
+
+> 작성일: 2026-02-17
+> 목적: 경쟁 서비스 분석 및 ClaudeShip 차별화 기능 도출
+
+---
+
+## 1. Replit Agent 주요 기능
+
+### 1.1 Agent 3 모드
+
+| 모드 | 설명 |
+|------|------|
+| **Plan** | 구현 전 계획 수립, 사용자 확인 후 실행 |
+| **Build** | 전체 앱 빌드 (풀스택) |
+| **Edit** | 기존 코드 수정/개선 |
+| **Design** | Figma import 지원 |
+| **Fast Build** | 빠른 프로토타이핑 |
+
+### 1.2 개발 인프라
+
+| 기능 | 설명 |
+|------|------|
+| 배포 | 원클릭 배포, 커스텀 도메인 |
+| 터미널 | 내장 Shell |
+| 파일 편집 | Monaco Editor 통합 |
+| 패키지 관리 | UI 기반 의존성 관리 |
+| 멀티플레이어 | 실시간 협업 |
+| 모바일 앱 | iOS/Android 앱 |
+| AI 모델 | 300+ 모델 지원 |
+| 보안 스캔 | 자동 코드 보안 분석 |
+
+### 1.3 Replit의 약점
+
+- **코드 품질**: God component, 중복 코드, flat 구조
+- **폴더 구조**: 기능별 분리 없이 단일 디렉토리
+- **네이밍**: 일관성 없는 변수/파일명
+- **리팩토링**: 코드가 커지면 구조 개선 불가
+
+---
+
+## 2. Claude Code CLI 주요 기능
+
+### 2.1 실행 모드
+
+| 모드 | CLI 플래그 | 도구 제한 |
+|------|-----------|----------|
+| **Normal** | (기본) | 모든 도구 |
+| **Plan** | `--tools "Read,Glob,Grep,..."` | 읽기 전용 + Task, TodoWrite |
+| **Auto-accept** | `--dangerously-skip-permissions` | 권한 자동 수락 |
+
+### 2.2 서브에이전트 시스템
+
+```mermaid
+flowchart LR
+    Main[메인 에이전트] --> E[Explore Agent]
+    Main --> P[Plan Agent]
+    Main --> G[General-purpose Agent]
+    Main --> C[Custom YAML Agent]
+
+    E --> |"빠른 코드 검색"| Result1[파일/패턴 매칭]
+    P --> |"설계 계획"| Result2[구현 전략]
+    G --> |"복잡한 작업"| Result3[멀티스텝 결과]
+    C --> |"사용자 정의"| Result4[커스텀 결과]
+```
+
+| 에이전트 | 용도 |
+|---------|------|
+| Explore | 코드베이스 빠른 탐색 |
+| Plan | 구현 전략 설계 |
+| General-purpose | 복잡한 멀티스텝 작업 |
+| Custom (YAML) | `.claude/agents/*.yml` 사용자 정의 에이전트 |
+
+### 2.3 기타 기능
+
+- **Hooks**: PreToolUse, PostToolUse, SubagentStart/Stop 라이프사이클
+- **MCP 서버**: 외부 도구 통합
+- **Persistent Memory**: `.claude/` 폴더 기반 메모리
+- **Agent SDK**: 커스텀 에이전트 빌드 프레임워크
+- **Stream JSON**: `--output-format stream-json` 실시간 이벤트
+
+---
+
+## 3. ClaudeShip 현재 기능 맵
+
+### 3.1 구현 완료
+
+| 영역 | 기능 | 상태 |
+|------|------|------|
+| 채팅 | Ask/Build 2단 모드 | ✅ |
+| 채팅 | SSE 스트리밍 | ✅ |
+| 채팅 | 메시지 큐잉 | ✅ |
+| 채팅 | AskUserQuestion 지원 | ✅ |
+| 채팅 | 파일 첨부 | ✅ |
+| 프리뷰 | 자동 시작/중지 | ✅ |
+| 프리뷰 | 디바이스 프리셋 | ✅ |
+| 프리뷰 | 에러 오버레이 | ✅ |
+| 프리뷰 | 콘솔 로그 뷰어 | ✅ |
+| 파일 | 파일 탐색기 | ✅ |
+| 파일 | 파일 뷰어 (읽기 전용) | ✅ |
+| 체크포인트 | Git 기반 자동 저장 | ✅ |
+| 체크포인트 | diff 뷰어 | ✅ |
+| 리뷰 | 코드 리뷰 (Architect) | ✅ |
+| 리뷰 | 자동 수정 (Auto-fix) | ✅ |
+| DB | Database Viewer | ✅ |
+| 테스트 | E2E 테스트 러너 | ✅ |
+| 환경 | 환경변수 관리 | ✅ |
+| 컨텍스트 | 프로젝트 컨텍스트 관리 | ✅ |
+
+### 3.2 미구현 (Phase 002 대상)
+
+| 영역 | 기능 | Replit | Claude Code |
+|------|------|-------|-------------|
+| 모드 | Plan Mode | ✅ | ✅ |
+| 상태 | 세션/비용 대시보드 | ❌ | CLI 출력 |
+| 시각화 | 도구 카테고리별 색상 | ❌ | ❌ |
+| 터미널 | 내장 터미널 | ✅ | CLI 자체 |
+| 편집 | 코드 편집기 | ✅ | ❌ |
+| 에러 | AI 자동수정 | ✅ | ❌ |
+| 에이전트 | 서브에이전트 시각화 | ❌ | CLI 로그 |
+| 에이전트 | 커스텀 에이전트 관리 | ❌ | YAML 직접 편집 |
+| 보안 | 코드 보안 스캔 | ✅ | ❌ |
+| 마법사 | 프로젝트 설정 | ✅ | ❌ |
+
+---
+
+## 4. 기능 우선순위 매트릭스
+
+```mermaid
+quadrantChart
+    title 기능 우선순위 (영향도 vs 구현 난이도)
+    x-axis 구현 쉬움 --> 구현 어려움
+    y-axis 영향도 낮음 --> 영향도 높음
+
+    P2-011 Plan Mode: [0.2, 0.8]
+    P2-012 Status Bar: [0.3, 0.6]
+    P2-013 Tool Viz: [0.3, 0.5]
+    P2-022 Error Fix: [0.4, 0.7]
+    P2-017 Architect+: [0.6, 0.8]
+    P2-014 Terminal: [0.7, 0.7]
+    P2-015 Editor: [0.7, 0.6]
+    P2-018 Subagent UI: [0.5, 0.5]
+    P2-019 Custom Agent: [0.6, 0.4]
+    P2-020 Checkpoint+: [0.4, 0.3]
+    P2-021 Wizard: [0.5, 0.5]
+```
+
+---
+
+## 5. 구현 로드맵
+
+```mermaid
+gantt
+    title Phase 002 구현 로드맵
+    dateFormat X
+    axisFormat %s
+
+    section 1단계: 모드 노출
+    P2-011 Plan Mode      :done, a1, 0, 1
+    P2-012 Status Bar     :done, a2, 0, 1
+    P2-013 Tool Viz       :done, a3, 0, 1
+
+    section 2단계: 생산성
+    P2-022 Error→AI Fix   :done, b1, 1, 2
+    P2-014 Web Terminal   :b2, 2, 4
+    P2-015 File Editor    :b3, 2, 4
+
+    section 3단계: 에이전트
+    P2-017 Architect+     :c1, 4, 6
+    P2-018 Subagent UI    :c2, 4, 6
+    P2-019 Custom Agent   :c3, 5, 7
+
+    section 4단계: 완성도
+    P2-020 Checkpoint+    :d1, 7, 8
+    P2-021 Setup Wizard   :d2, 7, 9
+```

--- a/design/phase-002/003-claude-mode-features.md
+++ b/design/phase-002/003-claude-mode-features.md
@@ -1,0 +1,175 @@
+# 1단계: Claude Code 모드 노출 기능 설계
+
+> P2-011, P2-012, P2-013
+> 상태: 구현 완료
+
+---
+
+## 1. P2-011: Plan Mode 지원
+
+### 1.1 개요
+
+Claude Code CLI의 3가지 모드(Ask/Plan/Build)를 웹 UI에서 모두 지원합니다.
+
+### 1.2 모드 정의
+
+| 모드 | 용도 | 허용 도구 | UI 색상 |
+|------|------|----------|---------|
+| **Ask** | 질문/조회 | Read, Glob, Grep, LSP, WebFetch, WebSearch | 파랑 (`blue-500`) |
+| **Plan** | 구현 계획 수립 | Ask 도구 + Task, TodoWrite | 보라 (`violet-500`) |
+| **Build** | 실제 구현 | 모든 도구 | 초록 (`green-500`) |
+
+### 1.3 변경 파일
+
+```mermaid
+flowchart LR
+    subgraph Shared
+        A[packages/shared/src/types/chat.ts]
+    end
+
+    subgraph Backend
+        B[apps/server/src/chat/dto/send-message.dto.ts]
+        C[apps/server/src/chat/claude-cli.service.ts]
+    end
+
+    subgraph Frontend
+        D[apps/web/src/components/chat/ModeToggle.tsx]
+        E[apps/web/src/components/chat/MessageInput.tsx]
+        F[apps/web/src/lib/i18n/translations/*.json]
+    end
+
+    A --> B
+    A --> D
+```
+
+### 1.4 구현 상세
+
+#### 타입 변경
+```typescript
+// packages/shared/src/types/chat.ts
+export type ChatMode = "ask" | "build" | "plan";  // "plan" 추가
+```
+
+#### CLI 도구 제한
+```typescript
+// claude-cli.service.ts
+const ASK_MODE_TOOLS = ["Read", "Glob", "Grep", "LSP", "WebFetch", "WebSearch"];
+const PLAN_MODE_TOOLS = ["Read", "Glob", "Grep", "LSP", "WebFetch", "WebSearch", "Task", "TodoWrite"];
+// Build 모드: 도구 제한 없음
+```
+
+#### UI 토글
+- 3버튼 토글: Ask (파랑) → Plan (보라) → Build (초록)
+- 스트리밍 중 비활성화
+- 모드별 placeholder 텍스트 변경
+
+---
+
+## 2. P2-012: Claude Code 상태 대시보드
+
+### 2.1 개요
+
+채팅 패널 헤더 아래에 컴팩트한 상태 바를 추가하여 현재 세션 정보를 실시간 표시합니다.
+
+### 2.2 표시 정보
+
+| 항목 | 소스 | 표시 조건 |
+|------|------|----------|
+| 현재 모드 | `useChatStore.mode` | 항상 |
+| 활성 상태 | `useChatStore.isStreaming` | 스트리밍 중 |
+| 경과 시간 | `streamStartedAt` → 계산 | 스트리밍 중 |
+| 도구 사용 수 | `streamingBlocks` 카운트 | 도구 사용 시 |
+| 비용 | SSE `complete` 이벤트 | 완료 후 |
+
+### 2.3 컴포넌트 구조
+
+```
+ClaudeStatusBar
+├── Mode Indicator (모드 배지 + 아이콘)
+├── Activity Status (Active 표시 + 애니메이션)
+├── Duration Timer (경과 시간)
+├── Tool Count (도구 사용 수 + 실행 중 수)
+└── Cost Display (마지막/총 비용)
+```
+
+### 2.4 Store 확장
+
+```typescript
+// useChatStore에 추가된 상태
+interface ChatState {
+  // ... 기존 상태
+  sessionId: string | null;      // init 이벤트에서 추출
+  lastCost: number | null;       // 마지막 응답 비용
+  totalCost: number;             // 세션 총 비용
+  streamStartedAt: number | null; // 타이머용
+}
+```
+
+### 2.5 SSE 이벤트 처리
+
+```mermaid
+sequenceDiagram
+    participant CLI as Claude CLI
+    participant API as Backend
+    participant Store as useChatStore
+    participant UI as ClaudeStatusBar
+
+    CLI->>API: init event (sessionId)
+    API->>Store: set sessionId
+    Store->>UI: 세션 ID 표시
+
+    CLI->>API: tool_use events
+    API->>Store: streamingBlocks 추가
+    Store->>UI: 도구 카운트 업데이트
+
+    CLI->>API: complete event (cost)
+    API->>Store: set lastCost, totalCost
+    Store->>UI: 비용 표시
+```
+
+---
+
+## 3. P2-013: 도구 사용 시각화 개선
+
+### 3.1 개요
+
+도구 사용을 카테고리별로 색상 구분하고, 도구 그룹에 요약 배지를 표시합니다.
+
+### 3.2 도구 카테고리
+
+| 카테고리 | 도구 | 색상 |
+|---------|------|------|
+| **File** | Read, Edit, Write | 파랑 (`blue`) |
+| **Search** | Glob, Grep | 보라 (`purple`) |
+| **System** | Bash | 주황 (`orange`) |
+| **Web** | WebFetch, WebSearch | 에메랄드 (`emerald`) |
+| **Agent** | Task, TodoWrite | 바이올렛 (`violet`) |
+
+### 3.3 시각화 요소
+
+#### 도구 블록 (ToolUseBlock)
+- 실행 중: 해당 카테고리 색상 배경 + 스피너
+- 완료: 회색 배경 + 체크 아이콘
+- 실행 시간 표시 (`ms` 또는 `s`)
+
+#### 요약 배지 (ToolSummaryBadges)
+- 5개 이상 도구 그룹에 카테고리별 카운트 배지 표시
+- 예: `[File 3] [Search 2] [System 1] (4.2s)`
+- 접기/펼치기 기능 유지
+
+### 3.4 렌더링 구조
+
+```
+StreamingMessage
+├── BlockGroup (consecutive tool_use)
+│   ├── ToolSummaryBadges (≥5 tools)
+│   │   ├── [File 3]
+│   │   ├── [Search 2]
+│   │   └── (total duration)
+│   ├── ToolUseBlock (카테고리 색상)
+│   ├── ToolUseBlock
+│   ├── [N개 더 보기] (collapse)
+│   └── ToolUseBlock
+├── TextBlock (markdown)
+└── AskUserQuestionBlock
+```

--- a/design/phase-002/004-dev-productivity.md
+++ b/design/phase-002/004-dev-productivity.md
@@ -1,0 +1,194 @@
+# 2단계: 개발 생산성 기능 설계
+
+> P2-014, P2-015, P2-022
+> 상태: 구현 완료
+
+---
+
+## 1. P2-022: 에러 → AI 자동 수정 연결
+
+### 1.1 개요
+
+프리뷰 패널에서 감지된 에러를 한 번의 클릭으로 AI에게 전달하여 자동 수정합니다.
+
+### 1.2 흐름
+
+```mermaid
+sequenceDiagram
+    participant Preview as PreviewPanel
+    participant Error as ErrorOverlay
+    participant Chat as useChatStore
+    participant CLI as Claude CLI
+
+    Preview->>Preview: stderr 로그 스트림 감시
+    Preview->>Error: parseErrorFromLog() → ErrorInfo
+    Error->>Error: 에러 오버레이 표시
+
+    Note over Error: 사용자가 "AI Auto-fix" 클릭
+
+    Error->>Chat: setMode("build")
+    Error->>Chat: sendMessage(projectId, errorPrompt)
+    Chat->>CLI: Fix this compile error: ...
+    CLI-->>Chat: 수정 완료
+```
+
+### 1.3 구현 상세
+
+#### ErrorOverlay 확장
+- `projectId` prop 추가
+- "AI Auto-fix" 버튼 (`Wand2` 아이콘, 보라색)
+- 클릭 시: mode를 build로 변경 → 에러 정보를 프롬프트로 전송 → 오버레이 닫기
+
+#### 프롬프트 구성
+```
+Fix this {error.type} error:
+{error.message}
+File: {error.location.file}:{error.location.line}:{error.location.column}
+
+Stack trace:
+{error.stack}
+```
+
+### 1.4 변경 파일
+- `apps/web/src/components/preview/ErrorOverlay.tsx` - AI Auto-fix 버튼 추가
+- `apps/web/src/components/preview/PreviewPanel.tsx` - projectId 전달
+
+---
+
+## 2. P2-014: 웹 터미널
+
+### 2.1 개요
+
+xterm.js + node-pty를 사용한 내장 웹 터미널. 사용자가 프로젝트 디렉토리에서 직접 명령어를 실행할 수 있습니다.
+
+### 2.2 아키텍처
+
+```mermaid
+flowchart LR
+    subgraph Frontend
+        XT[xterm.js]
+        WS1[WebSocket Client]
+    end
+
+    subgraph Backend
+        WS2[WebSocket Gateway]
+        PTY[node-pty]
+    end
+
+    subgraph OS
+        Shell[bash/sh]
+    end
+
+    XT <--> WS1
+    WS1 <--> WS2
+    WS2 <--> PTY
+    PTY <--> Shell
+```
+
+### 2.3 프론트엔드
+
+#### 컴포넌트: `TerminalPanel`
+- xterm.js 기반 터미널 에뮬레이터
+- WebSocket으로 백엔드 PTY와 연결
+- 워크스페이스 탭에 "Terminal" 탭 추가
+
+#### 의존성
+```
+@xterm/xterm
+@xterm/addon-fit
+@xterm/addon-web-links
+```
+
+### 2.4 백엔드
+
+#### 모듈: `TerminalModule`
+- `TerminalGateway` (WebSocket): 터미널 I/O 중계
+- `TerminalService`: node-pty 프로세스 관리
+
+#### 의존성
+```
+node-pty
+```
+
+#### WebSocket 이벤트
+
+| 이벤트 | 방향 | 설명 |
+|--------|------|------|
+| `terminal:start` | Client → Server | 터미널 시작 (projectId) |
+| `terminal:input` | Client → Server | 사용자 입력 |
+| `terminal:output` | Server → Client | PTY 출력 |
+| `terminal:resize` | Client → Server | 창 크기 변경 |
+| `terminal:exit` | Server → Client | 프로세스 종료 |
+
+### 2.5 UI 배치
+
+```
+WorkspaceLayout 탭 바:
+[Preview] [Database] [Testing] [Review] [Checkpoint] [Env] [Context] [Terminal]
+                                                                       ^^^^^^^^ NEW
+```
+
+---
+
+## 3. P2-015: 파일 편집기
+
+### 3.1 개요
+
+현재 읽기 전용인 FileViewer를 CodeMirror 기반 편집기로 업그레이드합니다.
+
+### 3.2 아키텍처
+
+```mermaid
+flowchart LR
+    subgraph Frontend
+        FE[FileExplorer] --> Editor[CodeMirror Editor]
+        Editor --> Save[저장 API]
+    end
+
+    subgraph Backend
+        FC[FileController] --> FS[FileService]
+        FS --> Disk[파일 시스템]
+    end
+
+    Save --> FC
+```
+
+### 3.3 프론트엔드
+
+#### 컴포넌트: `FileEditor`
+- CodeMirror 6 기반 (가벼움, 모바일 지원)
+- 언어별 구문 강조 (TypeScript, Python, JSON, CSS, HTML 등)
+- 키바인딩: `Ctrl+S` 저장
+- 변경 표시 (dot indicator)
+
+#### 의존성
+```
+@codemirror/state
+@codemirror/view
+@codemirror/lang-javascript
+@codemirror/lang-python
+@codemirror/lang-json
+@codemirror/lang-css
+@codemirror/lang-html
+@codemirror/theme-one-dark
+```
+
+### 3.4 백엔드
+
+#### FileController 확장
+```
+PUT /projects/:projectId/files/content
+Body: { path: string, content: string }
+```
+
+#### 보안
+- 경로 검증 (디렉토리 트래버설 방지)
+- 프로젝트 루트 외부 접근 차단
+- 바이너리 파일 편집 차단
+
+### 3.5 FileExplorer 연동
+
+현재 FileViewer(모달)를 FileEditor로 교체:
+- 클릭 시 편집 모드로 열림
+- 저장 시 파일 시스템에 직접 쓰기
+- 저장 후 프리뷰 자동 새로고침

--- a/design/phase-002/005-agent-enhancement.md
+++ b/design/phase-002/005-agent-enhancement.md
@@ -1,0 +1,214 @@
+# 3단계: AI 에이전트 고도화 설계
+
+> P2-017, P2-018, P2-019
+> 상태: 구현 완료
+
+---
+
+## 1. P2-017: Architect Agent 고도화
+
+### 1.1 개요
+
+기존 코드 리뷰 기능에 보안 스캔, 코드 구조 분석, "Fix with Agent" 기능을 추가합니다.
+
+### 1.2 현재 구조
+
+```mermaid
+flowchart LR
+    Build[build.complete] --> Review[triggerReview]
+    Review --> CLI[Claude CLI ask 모드]
+    CLI --> Parse[JSON 파싱]
+    Parse --> DB[(DB 저장)]
+    Parse --> SSE[SSE 이벤트]
+```
+
+현재 리뷰 카테고리: `security`, `bug`, `architecture`, `performance`, `quality`
+
+### 1.3 추가 기능
+
+#### A. 보안 스캔 (OWASP Top 10)
+
+리뷰 프롬프트에 보안 체크리스트 추가:
+
+| OWASP 항목 | 체크 내용 |
+|-----------|----------|
+| A01: Broken Access Control | 인증/인가 누락 확인 |
+| A02: Cryptographic Failures | 하드코딩된 시크릿 |
+| A03: Injection | SQL/Command/XSS Injection |
+| A07: Auth Failures | 약한 비밀번호 정책 |
+| A09: Logging Failures | 민감 정보 로그 출력 |
+
+구현: `ArchitectService`의 리뷰 프롬프트에 보안 검사 섹션 추가.
+
+#### B. 코드 구조 분석
+
+Architect 프롬프트에 구조 분석 항목 추가:
+
+| 분석 항목 | 기준 |
+|----------|------|
+| 파일 크기 | 300줄 초과 시 경고 |
+| 폴더 깊이 | 5단계 이상 경고 |
+| God Component | 하나의 컴포넌트에 너무 많은 로직 |
+| 중복 코드 | 유사 패턴 반복 감지 |
+| 네이밍 일관성 | camelCase/PascalCase 혼용 |
+| 미사용 코드 | import 되었지만 사용되지 않는 모듈 |
+
+결과를 기존 `ReviewIssue`의 `category: "architecture"` 또는 `"quality"`로 분류.
+
+#### C. Fix with Agent
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant UI as IssueCard
+    participant Chat as ChatService
+    participant CLI as Claude CLI
+
+    User->>UI: "Fix" 버튼 클릭
+    UI->>Chat: sendMessage(mode="build", fixPrompt)
+    Chat->>CLI: Fix this issue: ...
+    CLI-->>Chat: 수정 완료
+    Chat-->>UI: build.complete → 재리뷰
+```
+
+- IssueCard에 "Fix" 버튼 추가 (`autoFixable === true`일 때)
+- 클릭 시 이슈 정보를 프롬프트로 구성하여 채팅에 전달
+- 수정 후 자동 재리뷰 트리거
+
+### 1.4 변경 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `architect.service.ts` | 리뷰 프롬프트에 보안/구조 분석 추가 |
+| `IssueCard.tsx` | "Fix" 버튼 추가 |
+| `ArchitectPanel.tsx` | 카테고리 필터 추가 |
+
+---
+
+## 2. P2-018: 서브에이전트 실행 UI
+
+### 2.1 개요
+
+Claude Code CLI가 실행하는 서브에이전트(Task 도구)의 진행 상태를 시각적으로 표시합니다.
+
+### 2.2 서브에이전트 이벤트 감지
+
+Claude CLI의 stream-json에서 `Task` 도구 사용 감지:
+
+```json
+{
+  "type": "assistant",
+  "message": {
+    "content": [{
+      "type": "tool_use",
+      "name": "Task",
+      "input": {
+        "description": "Explore codebase",
+        "prompt": "Find all API endpoints...",
+        "subagent_type": "Explore"
+      }
+    }]
+  }
+}
+```
+
+### 2.3 UI 컴포넌트
+
+#### SubagentBlock (StreamingMessage 내부)
+
+```
+┌─────────────────────────────────────────────┐
+│ 🤖 Explore Agent: "Explore codebase"        │
+│ ├─ 상태: 실행 중... (12s)                    │
+│ └─ [결과 보기]                               │
+└─────────────────────────────────────────────┘
+```
+
+- `Task` 도구를 특별한 블록으로 렌더링
+- 에이전트 타입 표시 (Explore, Plan, General-purpose)
+- 실행 시간 추적
+- 결과가 있으면 접기/펼치기로 표시
+
+### 2.4 구현 방식
+
+기존 `ToolUseBlock`에서 `Task` 도구일 때 확장된 UI를 렌더링:
+
+```typescript
+// StreamingMessage.tsx
+if (toolName === "Task") {
+  return <SubagentBlock block={block} />;
+}
+```
+
+### 2.5 변경 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `StreamingMessage.tsx` | Task 도구 특별 렌더링 |
+| `SubagentBlock.tsx` | 신규 컴포넌트 |
+
+---
+
+## 3. P2-019: 커스텀 에이전트 관리 UI
+
+### 3.1 개요
+
+`.claude/agents/` 디렉토리의 YAML 에이전트 파일을 웹 UI에서 관리합니다.
+
+### 3.2 YAML 에이전트 구조
+
+```yaml
+# .claude/agents/code-reviewer.yml
+name: Code Reviewer
+description: Reviews code for best practices
+tools:
+  - Read
+  - Glob
+  - Grep
+prompt: |
+  You are a code reviewer. Analyze the codebase and provide feedback.
+```
+
+### 3.3 UI 설계
+
+```
+┌─ Custom Agents ─────────────────────────────┐
+│                                              │
+│ ┌──────────────────────────────────────────┐ │
+│ │ 🤖 Code Reviewer                        │ │
+│ │ Reviews code for best practices          │ │
+│ │ Tools: Read, Glob, Grep                  │ │
+│ │ [실행] [편집] [삭제]                      │ │
+│ └──────────────────────────────────────────┘ │
+│                                              │
+│ ┌──────────────────────────────────────────┐ │
+│ │ 🤖 Security Auditor                     │ │
+│ │ Scans for security vulnerabilities       │ │
+│ │ Tools: Read, Glob, Grep, WebSearch       │ │
+│ │ [실행] [편집] [삭제]                      │ │
+│ └──────────────────────────────────────────┘ │
+│                                              │
+│ [+ 새 에이전트 생성]                          │
+└──────────────────────────────────────────────┘
+```
+
+### 3.4 백엔드 API
+
+```
+GET    /projects/:id/agents           → 에이전트 목록
+GET    /projects/:id/agents/:name     → 에이전트 상세
+POST   /projects/:id/agents           → 에이전트 생성
+PUT    /projects/:id/agents/:name     → 에이전트 수정
+DELETE /projects/:id/agents/:name     → 에이전트 삭제
+POST   /projects/:id/agents/:name/run → 에이전트 실행
+```
+
+### 3.5 변경 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `AgentModule` (NEW) | 백엔드 모듈 |
+| `AgentService` (NEW) | YAML 파일 CRUD |
+| `AgentController` (NEW) | REST API |
+| `AgentPanel.tsx` (NEW) | 프론트엔드 관리 UI |
+| `WorkspaceLayout.tsx` | "Agents" 탭 추가 |

--- a/design/phase-002/006-polish-features.md
+++ b/design/phase-002/006-polish-features.md
@@ -1,0 +1,140 @@
+# 4단계: 완성도 기능 설계
+
+> P2-020, P2-021
+> 상태: 구현 완료
+
+---
+
+## 1. P2-020: 체크포인트 타임라인 개선
+
+### 1.1 개요
+
+현재 리스트 형태의 체크포인트를 시각적 타임라인으로 개선하고, 미리보기 기능을 추가합니다.
+
+### 1.2 현재 vs 개선
+
+| 항목 | 현재 | 개선 |
+|------|------|------|
+| 레이아웃 | 단순 리스트 | 수직 타임라인 (점+선) |
+| 정보 | 메시지, 시간 | + 파일 수, 추가/삭제 라인 수, diff 요약 |
+| 인터랙션 | 클릭→diff | + 호버 미리보기, 복원 확인 다이얼로그 개선 |
+| 시각 | 텍스트 | + 변경량 막대 그래프 |
+
+### 1.3 타임라인 UI
+
+```
+  ●─── Auto checkpoint at 14:32:05
+  │    📄 3 files changed (+45, -12)
+  │    ▓▓▓▓░░░░ (insertions vs deletions)
+  │
+  ●─── Auto checkpoint at 14:28:11
+  │    📄 1 file changed (+8, -2)
+  │    ▓░
+  │
+  ●─── Manual: Initial setup
+  │    📄 5 files changed (+120, -0)
+  │    ▓▓▓▓▓▓▓▓
+  │
+  ◯ (프로젝트 시작)
+```
+
+### 1.4 컴포넌트 구조
+
+```
+CheckpointPanel
+├── CheckpointTimeline (수직 타임라인)
+│   ├── TimelineNode (각 체크포인트)
+│   │   ├── TimelineDot (● 또는 ◯)
+│   │   ├── TimelineInfo (메시지, 시간, 파일 수)
+│   │   └── ChangeBar (변경량 시각화)
+│   └── TimelineLine (연결선)
+├── DiffViewer (선택 시)
+└── RestoreDialog (복원 확인)
+```
+
+### 1.5 변경 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `CheckpointPanel.tsx` | 타임라인 레이아웃으로 변경 |
+| `TimelineNode.tsx` (NEW) | 타임라인 노드 컴포넌트 |
+
+---
+
+## 2. P2-021: 프로젝트 설정 마법사
+
+### 2.1 개요
+
+프로젝트 생성 시 단계별 마법사를 통해 최적의 설정을 선택하고, 클린 보일러플레이트를 생성합니다.
+
+### 2.2 마법사 단계
+
+```mermaid
+flowchart LR
+    A[1. 프로젝트 유형] --> B[2. 프레임워크 선택]
+    B --> C[3. 기능 선택]
+    C --> D[4. 확인 및 생성]
+```
+
+#### Step 1: 프로젝트 유형
+- 웹 앱 (Frontend Only)
+- 풀스택 앱 (Frontend + Backend)
+- API 서버 (Backend Only)
+- 모바일 앱 (React Native / Flutter)
+
+#### Step 2: 프레임워크 선택
+
+| 유형 | 프론트엔드 | 백엔드 |
+|------|-----------|--------|
+| 웹 | Next.js, React+Vite, Vue, SvelteKit | - |
+| 풀스택 | Next.js, React+Vite | Express, NestJS, FastAPI |
+| API | - | Express, NestJS, FastAPI, Django |
+| 모바일 | React Native, Expo, Flutter | - |
+
+#### Step 3: 기능 선택
+- 데이터베이스 (SQLite / PostgreSQL)
+- 인증 (NextAuth / Passport)
+- UI 라이브러리 (shadcn/ui / Tailwind / Material UI)
+- 테스트 (Playwright / Jest)
+
+#### Step 4: 확인 및 생성
+- 선택 요약 표시
+- "생성" 클릭 → AI가 보일러플레이트 생성
+- 생성 후 자동으로 프로젝트 페이지로 이동
+
+### 2.3 AI 프롬프트 생성
+
+마법사 선택을 기반으로 초기 프롬프트를 자동 구성:
+
+```
+Create a new {projectType} project with:
+- Frontend: {framework}
+- Backend: {backendFramework}
+- Database: {database}
+- Features: {features}
+
+Follow clean code conventions:
+- Organize files by feature/domain
+- Use consistent naming (camelCase for variables, PascalCase for components)
+- Keep components under 200 lines
+- Separate concerns (UI, logic, API)
+```
+
+### 2.4 컴포넌트 구조
+
+```
+CreateProjectModal → ProjectWizard (NEW)
+├── WizardStep1_Type
+├── WizardStep2_Framework
+├── WizardStep3_Features
+├── WizardStep4_Confirm
+└── WizardProgress (진행 표시)
+```
+
+### 2.5 변경 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `CreateProjectModal.tsx` | 마법사 UI로 교체 |
+| `ProjectWizard.tsx` (NEW) | 단계별 마법사 컴포넌트 |
+| `project.service.ts` | 마법사 데이터 기반 프로젝트 생성 |

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "node": ">=20.0.0",
     "pnpm": ">=9.0.0"
   },
-  "packageManager": "pnpm@9.15.0"
+  "packageManager": "pnpm@9.15.0",
+  "devDependencies": {
+    "@playwright/test": "^1.58.1"
+  }
 }

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -4,7 +4,7 @@ export enum Role {
   SYSTEM = "SYSTEM",
 }
 
-export type ChatMode = "ask" | "build";
+export type ChatMode = "ask" | "build" | "plan";
 
 export interface ChatMessage {
   id: string;

--- a/packages/shared/src/types/project.ts
+++ b/packages/shared/src/types/project.ts
@@ -55,6 +55,7 @@ export interface CreateProjectInput {
   frontendFramework?: FrontendFramework;
   backendFramework?: BackendFramework;
   description?: string;
+  features?: string[];
 }
 
 export interface ProjectListItem {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.1
+        version: 1.58.1
 
   apps/server:
     dependencies:
@@ -139,7 +143,7 @@ importers:
         version: 0.460.0(react@19.2.3)
       next:
         specifier: ^15.1.0
-        version: 15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 15.5.9(@playwright/test@1.58.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       prism-react-renderer:
         specifier: ^2.4.1
         version: 2.4.1(react@19.2.3)
@@ -203,13 +207,13 @@ importers:
         version: 0.460.0(react@19.2.3)
       next:
         specifier: ^15.5.9
-        version: 15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 15.5.9(@playwright/test@1.58.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nextra:
         specifier: '4'
-        version: 4.6.1(next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 4.6.1(next@15.5.9(@playwright/test@1.58.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       nextra-theme-docs:
         specifier: '4'
-        version: 4.6.1(@types/react@19.2.7)(next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+        version: 4.6.1(@types/react@19.2.7)(next@15.5.9(@playwright/test@1.58.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@15.5.9(@playwright/test@1.58.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
       react:
         specifier: ^19.0.0
         version: 19.2.3
@@ -839,6 +843,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.58.1':
+    resolution: {integrity: sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@prisma/client@6.19.1':
     resolution: {integrity: sha512-4SXj4Oo6HyQkLUWT8Ke5R0PTAfVOKip5Roo+6+b2EDTkFg5be0FnBWiuRJc0BC0sRQIWGMLKW1XguhVfW/z3/A==}
@@ -2942,6 +2951,11 @@ packages:
   fs-monkey@1.1.0:
     resolution: {integrity: sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4205,6 +4219,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.58.1:
+    resolution: {integrity: sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.1:
+    resolution: {integrity: sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -5936,6 +5960,10 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.2.9': {}
+
+  '@playwright/test@1.58.1':
+    dependencies:
+      playwright: 1.58.1
 
   '@prisma/client@6.19.1(prisma@6.19.1(typescript@5.9.3))(typescript@5.9.3)':
     optionalDependencies:
@@ -8383,6 +8411,9 @@ snapshots:
 
   fs-monkey@1.1.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -9725,7 +9756,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@15.5.9(@playwright/test@1.58.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 15.5.9
       '@swc/helpers': 0.5.15
@@ -9743,18 +9774,19 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.7
       '@next/swc-win32-arm64-msvc': 15.5.7
       '@next/swc-win32-x64-msvc': 15.5.7
+      '@playwright/test': 1.58.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextra-theme-docs@4.6.1(@types/react@19.2.7)(next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
+  nextra-theme-docs@4.6.1(@types/react@19.2.7)(next@15.5.9(@playwright/test@1.58.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@15.5.9(@playwright/test@1.58.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
     dependencies:
       '@headlessui/react': 2.2.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       clsx: 2.1.1
-      next: 15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 15.5.9(@playwright/test@1.58.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      nextra: 4.6.1(next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      nextra: 4.6.1(next@15.5.9(@playwright/test@1.58.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react: 19.2.3
       react-compiler-runtime: 19.1.0-rc.3(react@19.2.3)
       react-dom: 19.2.3(react@19.2.3)
@@ -9766,7 +9798,7 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  nextra@4.6.1(next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
+  nextra@4.6.1(next@15.5.9(@playwright/test@1.58.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.2
       '@headlessui/react': 2.2.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -9787,7 +9819,7 @@ snapshots:
       mdast-util-gfm: 3.1.0
       mdast-util-to-hast: 13.2.1
       negotiator: 1.0.0
-      next: 15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 15.5.9(@playwright/test@1.58.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-compiler-runtime: 19.1.0-rc.3(react@19.2.3)
       react-dom: 19.2.3(react@19.2.3)
@@ -10086,6 +10118,14 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  playwright-core@1.58.1: {}
+
+  playwright@1.58.1:
+    dependencies:
+      playwright-core: 1.58.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 


### PR DESCRIPTION
## Summary
- **1단계 Claude Code 모드 노출**: Plan/Build/Ask 3단 모드 토글(P2-011), Claude 상태 대시보드(P2-012), 도구 카테고리별 시각화(P2-013)
- **2단계 개발 생산성**: 웹 터미널(P2-014), 파일 편집기(P2-015), 에러→AI 자동수정(P2-022)
- **3단계 AI 에이전트 고도화**: Architect 보안 스캔 + Fix 버튼(P2-017), 서브에이전트 실행 UI(P2-018), 커스텀 에이전트 관리(P2-019)
- **4단계 완성도**: 체크포인트 타임라인 개선(P2-020), 프로젝트 설정 마법사(P2-021)

### 주요 변경
- 40 files changed, 3134 insertions(+), 454 deletions(-)
- 새 모듈: AgentModule, TerminalModule
- 새 컴포넌트: ClaudeStatusBar, SubagentBlock, AgentPanel, TerminalPanel
- 설계 문서 5개 추가

## Test plan
- [x] `pnpm build` 성공 확인

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)